### PR TITLE
Frontend as git submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,6 +176,5 @@ pytest.ini
 .env
 .local
 restai.db
-frontend
 restai_prod
 lab.py

--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ pytest.ini
 restai.db
 restai_prod
 lab.py
+
+# pyenv
+.python-version

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "frontend"]
+	path = frontend
+	url = https://github.com/apocas/restai-frontend

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ database:
 
 .PHONY: frontend
 frontend:
-	cd frontend && git pull && npm install && npm run build
+	cd frontend && npm install && npm run build
 
 .PHONY: dev
 dev:
@@ -61,3 +61,9 @@ dockernpminstall:
 .PHONY: dockernpmbuild
 dockernpmbuild:
 	cd frontend && docker run --rm -t -i -v $(shell pwd):/app --workdir /app node:12.18.1 make npmbuild
+
+.PHONY: update_frontend_submodule
+update_frontend_submodule:
+	git submodule update --remote frontend
+	git add frontend
+	git commit -m '[AUTO] Frontend Submodule update'

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ dev:
 install:
 	poetry install
 	make database
-	git clone https://github.com/apocas/restai-frontend frontend
+	git submodule init
+	git submodule update
 	make frontend
 
 .PHONY: installgpu


### PR DESCRIPTION
In this PR, I made the frontend a Git submodule.
Git submodule - connecting one Git repository to another
[About git submodules](https://git-scm.com/docs/git-submodule)
**To install the update you must delete the `frontend` folder, download the changes and run `make install`**
I also added a command to the make that will update the submodule to the latest version. If you made changes to the frontend, you should run `make update_frontend_submodule`