### PR TITLE
perf(restai): set a timeout on dalle3 HTTP calls

### DIFF
--- a/restai/image/external/dalle3.py
+++ b/restai/image/external/dalle3.py
@@ -9,7 +9,7 @@ def generate(imageModel: ImageModel):
     model.model_name = "dall-e-3"
     image_url = model.run(imageModel.prompt)
 
-    response = requests.get(image_url)
+    response = requests.get(image_url, timeout=10.0)
     response.raise_for_status()
     image_data = response.content
     return base64.b64encode(image_data).decode('utf-8')

--- a/restai/llms/tools/crawler_classic.py
+++ b/restai/llms/tools/crawler_classic.py
@@ -15,6 +15,6 @@ def crawler_classic(
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"
     }
 
-    response = requests.get(url, headers=headers)
+    response = requests.get(url, headers=headers, timeout=10.0)
     soup = BeautifulSoup(response.content, "html.parser")
     return soup.get_text()


### PR DESCRIPTION
I ran into this while reading through the code path around restai/image/external/dalle3.py. Set a timeout on dalle3 HTTP calls. Network calls without a timeout can hang a worker indefinitely. I kept the patch small and re-ran syntax checks after applying it.