### PR TITLE
Code formatting: apply Black style to projects.py, chat_resume.py, helper.py

### DIFF
--- a/restai/chat_resume.py
+++ b/restai/chat_resume.py
@@ -1,4 +1,4 @@
-"""Per-`chat_id` in-memory stream resume.
+"""Per-`chat_id` stream resume — in-memory, mirrored to Redis when configured.
 
 When a streaming /chat call's SSE connection drops (idle proxy timeout,
 flaky network, browser tab suspended), `@microsoft/fetch-event-source`
@@ -16,9 +16,24 @@ This module fixes that by keeping a per-`chat_id` `StreamSession` that:
   until the producer marks `done`
 - self-evicts a grace period after `done`
 
-In-memory only — works inside a single uvicorn worker. Multi-worker
-deployments would need Redis pub/sub, which is out of scope for this
-first cut (documented limitation).
+## Multi-instance
+
+The producer (detached agent run) lives on ONE instance, but a reconnect
+or Stop POST can land on ANY instance behind a load balancer. When Redis
+is configured (`config.build_redis_url()`), the producing instance keeps
+its fast in-memory session AND mirrors every event to a Redis Stream, so
+other instances can:
+- `lookup` / `get_or_create` find the session (shared producer claim lock)
+- `subscribe` replay + tail the buffer via the Redis Stream
+- `cancel` halt the remote producer over a Redis pub/sub control channel
+
+SSE event ids stay plain integers (assigned by the producer, stored as a
+field on each stream entry), so a reconnect's `Last-Event-ID` is a valid
+cursor regardless of which instance serves it.
+
+When Redis is NOT configured this is pure in-memory, single-instance —
+exactly the prior behavior. Redis errors degrade to in-memory (the
+same-instance stream keeps working; only cross-instance reach is lost).
 """
 
 from __future__ import annotations
@@ -27,9 +42,11 @@ import asyncio
 import json as _json
 import logging
 import time as _time
+import uuid as _uuid
 from dataclasses import dataclass, field
-from typing import AsyncIterator
+from typing import AsyncIterator, Optional, Union
 
+from restai import config
 
 logger = logging.getLogger("restai.chat_resume")
 
@@ -44,6 +61,106 @@ GRACE_SECONDS = 300
 # going to catch up live anyway.
 MAX_EVENTS_PER_SESSION = 5000
 
+# Producer-claim lock TTL. Outlasts any realistic agent turn; refreshed
+# on every append so a live producer keeps it, and a crashed producer's
+# lock expires (freeing the chat_id) within this window.
+PRODUCER_LOCK_TTL = 600
+
+# Stream/meta TTL while a producer is active. Dropped to GRACE_SECONDS on
+# finish/cancel so finished sessions self-expire like the in-memory ones.
+ACTIVE_TTL = 3600
+
+# How long an idle Redis subscriber blocks per XREAD before re-checking
+# the done flag. Small enough to notice end promptly, large enough to
+# avoid busy-looping.
+XREAD_BLOCK_MS = 5000
+
+_KEY_PREFIX = "chat_resume:"
+
+
+def _k_events(chat_id: str) -> str:
+    return f"{_KEY_PREFIX}{chat_id}:events"
+
+
+def _k_meta(chat_id: str) -> str:
+    return f"{_KEY_PREFIX}{chat_id}:meta"
+
+
+def _k_lock(chat_id: str) -> str:
+    return f"{_KEY_PREFIX}{chat_id}:lock"
+
+
+def _k_control(chat_id: str) -> str:
+    return f"{_KEY_PREFIX}{chat_id}:control"
+
+
+# --------------------------------------------------------------------------
+# Redis client (module-global, lazy, self-healing on URL change)
+# --------------------------------------------------------------------------
+
+_redis_client = None
+_redis_url: Optional[str] = None
+
+
+def _close_client_async(client) -> None:
+    """Fire-and-forget close of a superseded async Redis client."""
+    if client is None:
+        return
+    closer = getattr(client, "aclose", None) or getattr(client, "close", None)
+    if closer is None:
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    try:
+        loop.create_task(closer())
+    except Exception:
+        pass
+
+
+def _redis():
+    """Cached `redis.asyncio` client, or None when Redis is unconfigured /
+    unavailable. Rebuilds when the configured URL changes so admin Settings
+    edits are picked up without a restart."""
+    global _redis_client, _redis_url
+    url = config.build_redis_url()
+    if not url:
+        if _redis_client is not None:
+            _close_client_async(_redis_client)
+            _redis_client = None
+            _redis_url = None
+        return None
+    if _redis_client is not None and _redis_url == url:
+        return _redis_client
+    if _redis_client is not None:
+        _close_client_async(_redis_client)
+        _redis_client = None
+        _redis_url = None
+    try:
+        import redis.asyncio as aioredis  # type: ignore
+    except ImportError:
+        logger.warning(
+            "redis.asyncio not installed; chat_resume is single-instance only"
+        )
+        return None
+    try:
+        _redis_client = aioredis.from_url(url, decode_responses=True)
+        _redis_url = url
+    except Exception as e:
+        logger.warning(
+            "chat_resume: failed to build Redis client (%s); single-instance only", e
+        )
+        _redis_client = None
+        _redis_url = None
+        return None
+    return _redis_client
+
+
+# --------------------------------------------------------------------------
+# Producing session — in-memory buffer, optionally mirrored to Redis
+# --------------------------------------------------------------------------
+
 
 @dataclass
 class StreamSession:
@@ -57,6 +174,14 @@ class StreamSession:
     # Anyio Condition for live subscribers waiting on new chunks. We
     # rebuild it lazily on first await to bind it to the right loop.
     _cond: asyncio.Condition | None = None
+    # True when this session mirrors to Redis (Redis was configured when
+    # the producer was created). Stays fixed for the session's lifetime
+    # so the backend can't flip mid-stream.
+    _redis: bool = False
+    # Value written to the producer-claim lock; used for guarded release.
+    _lock_token: str | None = None
+    # Cross-instance cancel watcher (pub/sub subscriber) task.
+    _watcher: asyncio.Task | None = None
 
     def _condition(self) -> asyncio.Condition:
         if self._cond is None:
@@ -73,14 +198,20 @@ class StreamSession:
                 # will get nothing useful from a replay anyway.
                 del self.events[: len(self.events) - MAX_EVENTS_PER_SESSION]
             cond.notify_all()
+        if self._redis:
+            await self._mirror_append(seq, chunk)
         return seq
 
     async def finish(self) -> None:
         cond = self._condition()
         async with cond:
-            self.done = True
-            self.finished_at = _time.monotonic()
+            if not self.done:
+                self.done = True
+                self.finished_at = _time.monotonic()
             cond.notify_all()
+        self._stop_watcher()
+        if self._redis:
+            await self._mirror_end()
 
     async def cancel(self) -> None:
         """User-initiated stop: cancel the background producer task so
@@ -88,20 +219,30 @@ class StreamSession:
         push a final 'stopped' marker into the buffer, and mark done.
         Idempotent — calling on an already-done session is a no-op."""
         if self.done:
+            # Already ended; still nudge any remote producer to be safe.
+            if self._redis:
+                await self._publish_cancel()
             return
         task = self.producer_task
         if task is not None and not task.done():
             task.cancel()
         cond = self._condition()
+        markers: list[tuple[int, str]] = []
         async with cond:
-            if self.done:
-                return
-            seq = (self.events[-1][0] + 1) if self.events else 1
-            self.events.append((seq, "data: " + _json.dumps({"stopped": True}) + "\n\n"))
-            self.events.append((seq + 1, "event: close\n\n"))
-            self.done = True
-            self.finished_at = _time.monotonic()
+            if not self.done:
+                seq = (self.events[-1][0] + 1) if self.events else 1
+                stopped = "data: " + _json.dumps({"stopped": True}) + "\n\n"
+                close = "event: close\n\n"
+                self.events.append((seq, stopped))
+                self.events.append((seq + 1, close))
+                markers = [(seq, stopped), (seq + 1, close)]
+                self.done = True
+                self.finished_at = _time.monotonic()
             cond.notify_all()
+        self._stop_watcher()
+        if self._redis:
+            await self._publish_cancel()
+            await self._mirror_end(extra_markers=markers)
 
     async def subscribe(self, last_event_id: int = 0) -> AsyncIterator[str]:
         """Replay events with id > last_event_id, then yield live ones until done."""
@@ -126,47 +267,430 @@ class StreamSession:
                     return
                 await cond.wait()
 
+    async def is_in_flight(self) -> bool:
+        return not self.done
 
-# Process-global registry. Keyed by chat_id; weakref isn't appropriate
-# (we explicitly want to keep the session alive past the producer's
-# completion for the grace window).
+    # ---- Redis mirroring ------------------------------------------------
+
+    async def _mirror_append(self, seq: int, chunk: str) -> None:
+        client = _redis()
+        if client is None:
+            return
+        cid = self.chat_id
+        try:
+            await client.xadd(
+                _k_events(cid),
+                {"s": str(seq), "d": chunk},
+                maxlen=MAX_EVENTS_PER_SESSION,
+                approximate=True,
+            )
+            await client.expire(_k_events(cid), ACTIVE_TTL)
+            await client.expire(_k_lock(cid), PRODUCER_LOCK_TTL)
+        except Exception as e:
+            logger.warning("chat_resume: redis append mirror failed (%s)", e)
+
+    async def _mirror_end(
+        self, extra_markers: list[tuple[int, str]] | None = None
+    ) -> None:
+        """Write terminal markers + eof to Redis exactly once (HSETNX guard),
+        release our producer lock, and shrink the grace TTL. Safe to call
+        from any instance; only the guard winner writes the markers."""
+        client = _redis()
+        if client is None:
+            return
+        cid = self.chat_id
+        try:
+            won = await client.hsetnx(_k_meta(cid), "ended", "1")
+            if won:
+                for seq, chunk in extra_markers or []:
+                    await client.xadd(
+                        _k_events(cid),
+                        {"s": str(seq), "d": chunk},
+                        maxlen=MAX_EVENTS_PER_SESSION,
+                        approximate=True,
+                    )
+                await client.xadd(_k_events(cid), {"eof": "1"})
+                await client.hset(
+                    _k_meta(cid),
+                    mapping={"status": "done", "finished_at": str(_time.time())},
+                )
+            await self._release_lock(client)
+            await client.expire(_k_events(cid), GRACE_SECONDS)
+            await client.expire(_k_meta(cid), GRACE_SECONDS)
+        except Exception as e:
+            logger.warning("chat_resume: redis end mirror failed (%s)", e)
+
+    async def _release_lock(self, client) -> None:
+        """Delete the producer lock only if we still own it (guards against
+        deleting a lock a later producer claimed after ours expired)."""
+        if not self._lock_token:
+            return
+        try:
+            await client.eval(_UNLOCK_LUA, 1, _k_lock(self.chat_id), self._lock_token)
+        except Exception:
+            pass
+
+    async def _publish_cancel(self) -> None:
+        client = _redis()
+        if client is None:
+            return
+        try:
+            await client.publish(_k_control(self.chat_id), "cancel")
+        except Exception as e:
+            logger.warning("chat_resume: redis publish cancel failed (%s)", e)
+
+    # ---- Cross-instance cancel watcher ----------------------------------
+
+    def start_cancel_watcher(self) -> None:
+        """Spawn a pub/sub subscriber that cancels this producer when any
+        instance publishes 'cancel' on the control channel. No-op without
+        Redis or if already running."""
+        if not self._redis or self._watcher is not None:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        self._watcher = loop.create_task(self._watch_control())
+
+    async def _watch_control(self) -> None:
+        client = _redis()
+        if client is None:
+            return
+        pubsub = None
+        try:
+            pubsub = client.pubsub()
+            await pubsub.subscribe(_k_control(self.chat_id))
+            async for message in pubsub.listen():
+                if not message or message.get("type") != "message":
+                    continue
+                data = message.get("data")
+                if data == "cancel" or data == b"cancel":
+                    # Cancels the local producer task + emits the local
+                    # 'stopped' marker so this instance's subscribers see it.
+                    await self.cancel()
+                    break
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning("chat_resume: control watcher error (%s)", e)
+        finally:
+            if pubsub is not None:
+                try:
+                    await pubsub.unsubscribe(_k_control(self.chat_id))
+                except Exception:
+                    pass
+                try:
+                    closer = getattr(pubsub, "aclose", None) or getattr(
+                        pubsub, "close", None
+                    )
+                    if closer is not None:
+                        await closer()
+                except Exception:
+                    pass
+
+    def _stop_watcher(self) -> None:
+        w = self._watcher
+        if w is None:
+            return
+        self._watcher = None
+        try:
+            current = asyncio.current_task()
+        except RuntimeError:
+            current = None
+        # When cancel() is invoked BY the watcher itself, don't self-cancel
+        # mid-flight — let it finish the Redis mirror then exit via `break`.
+        if w is not current and not w.done():
+            w.cancel()
+
+
+# Lua: delete the lock only if its value matches our token.
+_UNLOCK_LUA = (
+    "if redis.call('get', KEYS[1]) == ARGV[1] then "
+    "return redis.call('del', KEYS[1]) else return 0 end"
+)
+
+
+# --------------------------------------------------------------------------
+# Redis subscriber proxy — used on instances that are NOT the producer
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class RedisSubscriberSession:
+    """Read-only view of a session whose producer runs on another instance.
+    Backed entirely by Redis. `subscribe` tails the stream; `cancel` signals
+    the producing instance over pub/sub and writes the terminal markers."""
+
+    chat_id: str
+    producer_task: asyncio.Task | None = None  # never set; API symmetry only
+
+    def start_cancel_watcher(self) -> None:
+        return  # proxies never produce
+
+    async def append(self, chunk: str) -> int:
+        return 0  # defensive: a proxy must never produce
+
+    async def finish(self) -> None:
+        return
+
+    async def is_in_flight(self) -> bool:
+        client = _redis()
+        if client is None:
+            return False
+        try:
+            return (await client.hget(_k_meta(self.chat_id), "status")) == "active"
+        except Exception:
+            return False
+
+    async def subscribe(self, last_event_id: int = 0) -> AsyncIterator[str]:
+        client = _redis()
+        if client is None:
+            return
+        cid = self.chat_id
+        cursor = "0"  # Redis stream entry-id cursor (distinct from SSE seq)
+
+        # Replay everything already in the stream, skipping seqs the client
+        # has already seen. Stop if we hit the eof marker.
+        try:
+            entries = await client.xrange(_k_events(cid), min="-", max="+")
+        except Exception as e:
+            logger.warning("chat_resume: redis replay failed (%s)", e)
+            entries = []
+        for entry_id, fields in entries:
+            cursor = entry_id
+            if "eof" in fields:
+                return
+            line = _render(fields, last_event_id)
+            if line is not None:
+                yield line
+
+        # Tail live entries.
+        while True:
+            try:
+                resp = await client.xread(
+                    {_k_events(cid): cursor}, block=XREAD_BLOCK_MS, count=64
+                )
+            except Exception as e:
+                logger.warning("chat_resume: redis tail failed (%s)", e)
+                return
+            if not resp:
+                # Idle timeout — stop if the producer finished, or the keys
+                # were evicted out from under us.
+                try:
+                    if (await client.hget(_k_meta(cid), "status")) == "done":
+                        return
+                    if not await client.exists(_k_events(cid)):
+                        return
+                except Exception:
+                    return
+                continue
+            for _stream, items in resp:
+                for entry_id, fields in items:
+                    cursor = entry_id
+                    if "eof" in fields:
+                        return
+                    line = _render(fields, last_event_id)
+                    if line is not None:
+                        yield line
+
+    async def cancel(self) -> None:
+        client = _redis()
+        if client is None:
+            return
+        cid = self.chat_id
+        # Halt the producer on whichever instance owns it.
+        try:
+            await client.publish(_k_control(cid), "cancel")
+        except Exception as e:
+            logger.warning("chat_resume: redis publish cancel failed (%s)", e)
+        # Write the terminal markers ourselves (guarded) in case the producer
+        # is unreachable, so cross-instance subscribers still stop cleanly.
+        try:
+            won = await client.hsetnx(_k_meta(cid), "ended", "1")
+            if won:
+                last_seq = 0
+                try:
+                    rev = await client.xrevrange(_k_events(cid), count=1)
+                    if rev and "s" in rev[0][1]:
+                        last_seq = int(rev[0][1]["s"])
+                except Exception:
+                    pass
+                stopped = "data: " + _json.dumps({"stopped": True}) + "\n\n"
+                close = "event: close\n\n"
+                await client.xadd(
+                    _k_events(cid),
+                    {"s": str(last_seq + 1), "d": stopped},
+                    maxlen=MAX_EVENTS_PER_SESSION,
+                    approximate=True,
+                )
+                await client.xadd(
+                    _k_events(cid),
+                    {"s": str(last_seq + 2), "d": close},
+                    maxlen=MAX_EVENTS_PER_SESSION,
+                    approximate=True,
+                )
+                await client.xadd(_k_events(cid), {"eof": "1"})
+                await client.hset(
+                    _k_meta(cid),
+                    mapping={"status": "done", "finished_at": str(_time.time())},
+                )
+            await client.delete(_k_lock(cid))
+            await client.expire(_k_events(cid), GRACE_SECONDS)
+            await client.expire(_k_meta(cid), GRACE_SECONDS)
+        except Exception as e:
+            logger.warning("chat_resume: redis proxy cancel failed (%s)", e)
+
+
+def _render(fields: dict, last_event_id: int) -> Optional[str]:
+    """Turn a Redis stream data entry into an SSE block, or None to skip."""
+    s = fields.get("s")
+    if s is None:
+        return None
+    try:
+        seq = int(s)
+    except (TypeError, ValueError):
+        return None
+    if seq <= last_event_id:
+        return None
+    return f"id: {seq}\n{fields.get('d', '')}"
+
+
+Session = Union[StreamSession, RedisSubscriberSession]
+
+
+# Process-local registry of producing sessions. Keyed by chat_id; weakref
+# isn't appropriate (we explicitly keep the session alive past the
+# producer's completion for the grace window).
 _sessions: dict[str, StreamSession] = {}
 _sessions_lock = asyncio.Lock()
 
 
-async def get_or_create(chat_id: str) -> tuple[StreamSession, bool]:
-    """Return (session, is_new). GCs expired sessions to bound the dict."""
+async def get_or_create(chat_id: str) -> tuple[Session, bool]:
+    """Return (session, is_new). `is_new` means the caller owns the producer
+    (should spawn the agent run). Attaches to an in-flight session for dedup;
+    a finished session is discarded so a reused chat_id starts a fresh run."""
     async with _sessions_lock:
         _gc_expired_locked()
         existing = _sessions.get(chat_id)
         if existing is not None:
-            return existing, False
-        sess = StreamSession(chat_id=chat_id)
-        _sessions[chat_id] = sess
-        return sess, True
+            if not existing.done:
+                return existing, False
+            # Finished local session: drop it so the new turn starts fresh.
+            _sessions.pop(chat_id, None)
+
+    client = _redis()
+    if client is None:
+        # In-memory only (single instance) — the prior behavior.
+        async with _sessions_lock:
+            existing = _sessions.get(chat_id)
+            if existing is not None and not existing.done:
+                return existing, False
+            sess = StreamSession(chat_id=chat_id, _redis=False)
+            _sessions[chat_id] = sess
+            return sess, True
+
+    # Redis on: claim the single-producer lock.
+    token = _uuid.uuid4().hex
+    try:
+        claimed = await client.set(
+            _k_lock(chat_id), token, nx=True, ex=PRODUCER_LOCK_TTL
+        )
+    except Exception as e:
+        logger.warning(
+            "chat_resume: lock claim failed (%s); falling back to in-memory", e
+        )
+        claimed = None
+
+    if claimed:
+        # We own the producer. Clear any leftover stream/meta from a prior
+        # finished turn on this chat_id, then mark active.
+        try:
+            await client.delete(_k_events(chat_id), _k_meta(chat_id))
+            await client.hset(
+                _k_meta(chat_id), mapping={"status": "active", "finished_at": ""}
+            )
+            await client.expire(_k_meta(chat_id), ACTIVE_TTL)
+        except Exception as e:
+            logger.warning("chat_resume: redis meta init failed (%s)", e)
+        async with _sessions_lock:
+            existing = _sessions.get(chat_id)
+            if existing is not None and not existing.done:
+                return existing, False
+            sess = StreamSession(chat_id=chat_id, _redis=True, _lock_token=token)
+            _sessions[chat_id] = sess
+            return sess, True
+
+    if claimed is None:
+        # Redis error — keep streaming locally (no cross-instance reach).
+        async with _sessions_lock:
+            existing = _sessions.get(chat_id)
+            if existing is not None and not existing.done:
+                return existing, False
+            sess = StreamSession(chat_id=chat_id, _redis=False)
+            _sessions[chat_id] = sess
+            return sess, True
+
+    # A producer is active on another instance — attach as a subscriber.
+    return RedisSubscriberSession(chat_id=chat_id), False
 
 
-async def lookup(chat_id: str) -> StreamSession | None:
+async def lookup(chat_id: str) -> Optional[Session]:
     async with _sessions_lock:
         _gc_expired_locked()
-        return _sessions.get(chat_id)
+        local = _sessions.get(chat_id)
+    if local is not None:
+        return local
+    client = _redis()
+    if client is None:
+        return None
+    try:
+        if (
+            await client.exists(_k_lock(chat_id))
+            or await client.exists(_k_meta(chat_id))
+            or await client.exists(_k_events(chat_id))
+        ):
+            return RedisSubscriberSession(chat_id=chat_id)
+    except Exception as e:
+        logger.warning("chat_resume: redis lookup failed (%s)", e)
+    return None
 
 
 async def evict(chat_id: str) -> bool:
-    """Remove a session from the registry immediately, regardless of
-    its done state or grace window. Used on user-initiated stop so the
-    next POST with the same chat_id starts a fresh agent run instead
-    of replaying the cancelled session's buffer. Returns True if a
-    session was removed."""
+    """Remove a session immediately, regardless of done state or grace
+    window. Used on user-initiated stop so the next POST with the same
+    chat_id starts a fresh agent run instead of replaying the cancelled
+    session's buffer. Returns True if anything was removed."""
     async with _sessions_lock:
-        return _sessions.pop(chat_id, None) is not None
+        had_local = _sessions.pop(chat_id, None) is not None
+    had_redis = await _evict_redis(chat_id)
+    return had_local or had_redis
+
+
+async def _evict_redis(chat_id: str) -> bool:
+    client = _redis()
+    if client is None:
+        return False
+    try:
+        await client.publish(_k_control(chat_id), "cancel")
+    except Exception:
+        pass
+    try:
+        n = await client.delete(_k_events(chat_id), _k_meta(chat_id), _k_lock(chat_id))
+        return bool(n)
+    except Exception as e:
+        logger.warning("chat_resume: redis evict failed (%s)", e)
+        return False
 
 
 def _gc_expired_locked() -> None:
     now = _time.monotonic()
     drop = [
-        cid for cid, s in _sessions.items()
-        if s.done and s.finished_at is not None and (now - s.finished_at) > GRACE_SECONDS
+        cid
+        for cid, s in _sessions.items()
+        if s.done
+        and s.finished_at is not None
+        and (now - s.finished_at) > GRACE_SECONDS
     ]
     for cid in drop:
         _sessions.pop(cid, None)

--- a/restai/helper.py
+++ b/restai/helper.py
@@ -26,7 +26,12 @@ from restai.config import LOG_LEVEL
 import json
 
 from restai.projects.base import ProjectBase
-from restai.budget import check_budget, check_rate_limit, check_api_key_quota, record_api_key_tokens
+from restai.budget import (
+    check_budget,
+    check_rate_limit,
+    check_api_key_quota,
+    record_api_key_tokens,
+)
 
 logging.basicConfig(level=LOG_LEVEL)
 logger = logging.getLogger(__name__)
@@ -71,7 +76,9 @@ def resolve_image(image: str) -> str:
 
         if _is_private_ip(hostname):
             logger.warning("Blocked SSRF attempt to internal address: %s", hostname)
-            raise ValueError(f"Access to internal/private addresses is not allowed: {hostname}")
+            raise ValueError(
+                f"Access to internal/private addresses is not allowed: {hostname}"
+            )
 
         response = requests.get(image, timeout=10, stream=True)
         response.raise_for_status()
@@ -82,7 +89,9 @@ def resolve_image(image: str) -> str:
             downloaded += len(chunk)
             if downloaded > MAX_IMAGE_SIZE:
                 response.close()
-                raise ValueError(f"Image exceeds maximum allowed size of {MAX_IMAGE_SIZE} bytes.")
+                raise ValueError(
+                    f"Image exceeds maximum allowed size of {MAX_IMAGE_SIZE} bytes."
+                )
             chunks.append(chunk)
 
         content = b"".join(chunks)
@@ -113,11 +122,13 @@ def _attachment_meta(files):
             size = len(f.content or "") if isinstance(f.content, str) else 0
         except Exception:
             size = 0
-        meta.append({
-            "name": getattr(f, "name", None) or "",
-            "mime_type": getattr(f, "mime_type", None),
-            "size": size,
-        })
+        meta.append(
+            {
+                "name": getattr(f, "name", None) or "",
+                "mime_type": getattr(f, "mime_type", None),
+                "size": size,
+            }
+        )
     return meta
 
 
@@ -223,7 +234,10 @@ def _log_inference_error(
         pass
     try:
         log_inference(
-            project, user, output, db,
+            project,
+            user,
+            output,
+            db,
             latency_ms=latency_ms,
             system_prompt=system_prompt,
             context=context,
@@ -295,7 +309,9 @@ async def _drain_generator_into_session(
             }
             final_output = err_output
             try:
-                await resume_session.append("data: " + json.dumps({"text": err_output["answer"]}) + "\n\n")
+                await resume_session.append(
+                    "data: " + json.dumps({"text": err_output["answer"]}) + "\n\n"
+                )
                 await resume_session.append("data: " + json.dumps(err_output) + "\n")
             except Exception:
                 pass
@@ -315,17 +331,33 @@ async def _drain_generator_into_session(
                     final_output["image"] = image
                 if attachments and not final_output.get("attachments"):
                     final_output["attachments"] = attachments
-                latency_ms = int((time.perf_counter() - start_time) * 1000) if start_time else None
+                latency_ms = (
+                    int((time.perf_counter() - start_time) * 1000)
+                    if start_time
+                    else None
+                )
                 log_inference(
-                    project, user, final_output, db_local,
-                    latency_ms=latency_ms, system_prompt=system_prompt, context=context,
+                    project,
+                    user,
+                    final_output,
+                    db_local,
+                    latency_ms=latency_ms,
+                    system_prompt=system_prompt,
+                    context=context,
                 )
             elif not completed:
                 _log_inference_error(
-                    project, user, db_local,
-                    question=question, image=image, attachments=attachments,
-                    status="error", error="Agent generator stopped before completion",
-                    system_prompt=system_prompt, context=context, start_time=start_time,
+                    project,
+                    user,
+                    db_local,
+                    question=question,
+                    image=image,
+                    attachments=attachments,
+                    status="error",
+                    error="Agent generator stopped before completion",
+                    system_prompt=system_prompt,
+                    context=context,
+                    start_time=start_time,
                 )
         except Exception:
             logging.exception("log_inference failed in _drain_generator_into_session")
@@ -359,19 +391,31 @@ async def create_streaming_response_with_logging(
     if chat_id:
         import asyncio as _asyncio
         from restai import chat_resume as _resume
+
         resume_session, is_new = await _resume.get_or_create(chat_id)
         if is_new:
-            task = _asyncio.create_task(_drain_generator_into_session(
-                generator, resume_session,
-                project=project, user=user,
-                system_prompt=system_prompt, context=context,
-                question=question, image=image, attachments=attachments,
-                start_time=start_time,
-            ))
+            task = _asyncio.create_task(
+                _drain_generator_into_session(
+                    generator,
+                    resume_session,
+                    project=project,
+                    user=user,
+                    system_prompt=system_prompt,
+                    context=context,
+                    question=question,
+                    image=image,
+                    attachments=attachments,
+                    start_time=start_time,
+                )
+            )
             # Hold a strong ref on the session so asyncio doesn't GC the
             # task while it's running (the request task that spawned it
             # may already be torn down before the first chunk lands).
             resume_session.producer_task = task
+            # When Redis is configured, listen for a cross-instance Stop so
+            # the agent halts even if the /chat/stop POST lands elsewhere.
+            # No-op without Redis.
+            resume_session.start_cancel_watcher()
         else:
             # Re-POST while a producer is already running — we don't
             # need a second producer, and we MUST close the generator
@@ -384,6 +428,7 @@ async def create_streaming_response_with_logging(
         async def _subscribe():
             async for chunk in resume_session.subscribe(last_event_id=0):
                 yield chunk
+
         return StreamingResponse(_subscribe(), media_type="text/event-stream")
 
     # Non-resume path (no chat_id): legacy direct streaming. Generator
@@ -437,18 +482,32 @@ async def create_streaming_response_with_logging(
                         final_output["image"] = image
                     if attachments and not final_output.get("attachments"):
                         final_output["attachments"] = attachments
-                    latency_ms = int((time.perf_counter() - start_time) * 1000) if start_time else None
+                    latency_ms = (
+                        int((time.perf_counter() - start_time) * 1000)
+                        if start_time
+                        else None
+                    )
                     log_inference(
-                        project, user, final_output, db,
-                        latency_ms=latency_ms, system_prompt=system_prompt, context=context,
+                        project,
+                        user,
+                        final_output,
+                        db,
+                        latency_ms=latency_ms,
+                        system_prompt=system_prompt,
+                        context=context,
                     )
                 elif not completed:
                     _log_inference_error(
-                        project, user, db,
-                        question=question, image=image, attachments=attachments,
+                        project,
+                        user,
+                        db,
+                        question=question,
+                        image=image,
+                        attachments=attachments,
                         status="disconnected",
                         error="Client disconnected before stream completed",
-                        system_prompt=system_prompt, context=context,
+                        system_prompt=system_prompt,
+                        context=context,
                         start_time=start_time,
                     )
             except Exception:
@@ -495,10 +554,17 @@ async def chat_main(
         check_budget(project, db)
     except HTTPException as e:
         _log_inference_error(
-            project, user, db,
-            question=_question, image=_image, attachments=_attachments,
-            status="budget", error=getattr(e, "detail", str(e)),
-            system_prompt=_sys, context=_ctx, start_time=start_time,
+            project,
+            user,
+            db,
+            question=_question,
+            image=_image,
+            attachments=_attachments,
+            status="budget",
+            error=getattr(e, "detail", str(e)),
+            system_prompt=_sys,
+            context=_ctx,
+            start_time=start_time,
         )
         raise
 
@@ -506,10 +572,17 @@ async def chat_main(
         check_rate_limit(project, db)
     except HTTPException as e:
         _log_inference_error(
-            project, user, db,
-            question=_question, image=_image, attachments=_attachments,
-            status="rate_limit", error=getattr(e, "detail", str(e)),
-            system_prompt=_sys, context=_ctx, start_time=start_time,
+            project,
+            user,
+            db,
+            question=_question,
+            image=_image,
+            attachments=_attachments,
+            status="rate_limit",
+            error=getattr(e, "detail", str(e)),
+            system_prompt=_sys,
+            context=_ctx,
+            start_time=start_time,
         )
         raise
 
@@ -517,10 +590,17 @@ async def chat_main(
         check_api_key_quota(user, db)
     except HTTPException as e:
         _log_inference_error(
-            project, user, db,
-            question=_question, image=_image, attachments=_attachments,
-            status="quota", error=getattr(e, "detail", str(e)),
-            system_prompt=_sys, context=_ctx, start_time=start_time,
+            project,
+            user,
+            db,
+            question=_question,
+            image=_image,
+            attachments=_attachments,
+            status="quota",
+            error=getattr(e, "detail", str(e)),
+            system_prompt=_sys,
+            context=_ctx,
+            start_time=start_time,
         )
         raise
 
@@ -563,14 +643,23 @@ async def chat_main(
             async for line in output_generator:
                 if not isinstance(line, dict):
                     continue
-                latency_ms = int((time.perf_counter() - start_time) * 1000) if start_time else None
+                latency_ms = (
+                    int((time.perf_counter() - start_time) * 1000)
+                    if start_time
+                    else None
+                )
                 if _image and not line.get("image"):
                     line["image"] = _image
                 if _attachments and not line.get("attachments"):
                     line["attachments"] = _attachments
                 log_inference(
-                    project, user, line, db,
-                    latency_ms=latency_ms, system_prompt=_sys, context=_ctx,
+                    project,
+                    user,
+                    line,
+                    db,
+                    latency_ms=latency_ms,
+                    system_prompt=_sys,
+                    context=_ctx,
                 )
                 # RAG-only retrieval-event logging.
                 if (
@@ -579,24 +668,39 @@ async def chat_main(
                     and project.props.type == "rag"
                 ):
                     from restai.tools import log_retrieval_events
-                    background_tasks.add_task(log_retrieval_events, project, line["sources"], db)
+
+                    background_tasks.add_task(
+                        log_retrieval_events, project, line["sources"], db
+                    )
                 return line
             return None
     except HTTPException as e:
         _log_inference_error(
-            project, user, db,
-            question=_question, image=_image, attachments=_attachments,
-            status="error", error=getattr(e, "detail", str(e)),
-            system_prompt=_sys, context=_ctx, start_time=start_time,
+            project,
+            user,
+            db,
+            question=_question,
+            image=_image,
+            attachments=_attachments,
+            status="error",
+            error=getattr(e, "detail", str(e)),
+            system_prompt=_sys,
+            context=_ctx,
+            start_time=start_time,
         )
         raise
     except Exception as e:
         _log_inference_error(
-            project, user, db,
-            question=_question, image=_image, attachments=_attachments,
-            status="error", error=str(e),
-            system_prompt=_sys, context=_ctx, start_time=start_time,
+            project,
+            user,
+            db,
+            question=_question,
+            image=_image,
+            attachments=_attachments,
+            status="error",
+            error=str(e),
+            system_prompt=_sys,
+            context=_ctx,
+            start_time=start_time,
         )
         raise
-
-

--- a/restai/routers/projects.py
+++ b/restai/routers/projects.py
@@ -72,7 +72,11 @@ from restai.vectordb.tools import (
     index_documents_classic,
     index_documents_docling,
 )
-from restai.models.databasemodels import OutputDatabase, ProjectDatabase, ProjectInvitationDatabase
+from restai.models.databasemodels import (
+    OutputDatabase,
+    ProjectDatabase,
+    ProjectInvitationDatabase,
+)
 from restai.settings import mask_key
 import datetime
 from sqlalchemy import func, Integer, case
@@ -80,7 +84,13 @@ import calendar
 import tempfile
 import shutil
 
-_SENSITIVE_OPTION_KEYS = ("telegram_token", "slack_bot_token", "connection", "ftp_password")
+_SENSITIVE_OPTION_KEYS = (
+    "telegram_token",
+    "slack_bot_token",
+    "connection",
+    "ftp_password",
+)
+
 
 def _mask_sync_sources(options: dict):
     """Mask sensitive credentials inside sync_sources list."""
@@ -89,10 +99,17 @@ def _mask_sync_sources(options: dict):
         return
     for src in sources:
         if isinstance(src, dict):
-            for key in ("s3_access_key", "s3_secret_key", "confluence_api_token", "sharepoint_client_secret", "gdrive_service_account_json"):
+            for key in (
+                "s3_access_key",
+                "s3_secret_key",
+                "confluence_api_token",
+                "sharepoint_client_secret",
+                "gdrive_service_account_json",
+            ):
                 val = src.get(key)
                 if val:
                     src[key] = mask_key(val)
+
 
 logging.basicConfig(level=config.LOG_LEVEL)
 
@@ -109,7 +126,11 @@ def get_project(projectID: int, db_wrapper: DBWrapper, brain: Brain):
 @router.get("/projects", response_model=ProjectsResponse, tags=["Projects"])
 async def route_get_projects(
     _: Request,
-    v_filter: str = Query("", alias="filter", description="Filter mode: 'public' to list only public projects, empty for all accessible projects"),
+    v_filter: str = Query(
+        "",
+        alias="filter",
+        description="Filter mode: 'public' to list only public projects, empty for all accessible projects",
+    ),
     start: int = Query(0, ge=0, le=100000, description="Pagination start offset"),
     end: int = Query(10000, ge=1, le=100000, description="Pagination end offset"),
     user: User = Depends(get_current_username),
@@ -119,7 +140,9 @@ async def route_get_projects(
     query = db_wrapper.db.query(ProjectDatabase)
 
     if v_filter == "public":
-        user_team_ids = {t.id for t in (user.teams or [])} | {t.id for t in (user.admin_teams or [])}
+        user_team_ids = {t.id for t in (user.teams or [])} | {
+            t.id for t in (user.admin_teams or [])
+        }
         if user.is_admin:
             query = query.filter(ProjectDatabase.public == True)
         else:
@@ -132,8 +155,10 @@ async def route_get_projects(
         if user.admin_teams:
             admin_team_ids = {t.id for t in user.admin_teams}
             team_project_ids = {
-                p[0] for p in db_wrapper.db.query(ProjectDatabase.id)
-                .filter(ProjectDatabase.team_id.in_(admin_team_ids)).all()
+                p[0]
+                for p in db_wrapper.db.query(ProjectDatabase.id)
+                .filter(ProjectDatabase.team_id.in_(admin_team_ids))
+                .all()
             }
             accessible_ids = accessible_ids | team_project_ids
         query = query.filter(ProjectDatabase.id.in_(accessible_ids))
@@ -146,7 +171,9 @@ async def route_get_projects(
     serialized_projects = []
     for project in projects:
         project_model = ProjectModel.model_validate(project)
-        project_model.creator_username = project.creator_user.username if project.creator_user else None
+        project_model.creator_username = (
+            project.creator_user.username if project.creator_user else None
+        )
 
         project_dict = project_model.model_dump()
 
@@ -189,7 +216,9 @@ async def get_projects_health(
         project_ids = list(user.get_project_ids())
 
     if user.api_key_allowed_projects is not None:
-        project_ids = [pid for pid in project_ids if pid in user.api_key_allowed_projects]
+        project_ids = [
+            pid for pid in project_ids if pid in user.api_key_allowed_projects
+        ]
 
     if not project_ids:
         return []
@@ -203,25 +232,39 @@ async def get_projects_health(
             func.count(OutputDatabase.id).label("requests"),
             func.avg(OutputDatabase.latency_ms).label("avg_latency"),
         )
-        .filter(OutputDatabase.project_id.in_(project_ids), OutputDatabase.date >= seven_days_ago)
+        .filter(
+            OutputDatabase.project_id.in_(project_ids),
+            OutputDatabase.date >= seven_days_ago,
+        )
         .group_by(OutputDatabase.project_id)
         .all()
     )
-    activity = {r.project_id: {"requests": r.requests, "avg_latency": r.avg_latency} for r in activity_rows}
+    activity = {
+        r.project_id: {"requests": r.requests, "avg_latency": r.avg_latency}
+        for r in activity_rows
+    }
 
     guard_rows = (
         db_wrapper.db.query(
             GuardEventDatabase.project_id,
             func.count(GuardEventDatabase.id).label("total"),
-            func.sum(case((GuardEventDatabase.action == "block", 1), else_=0)).label("blocks"),
+            func.sum(case((GuardEventDatabase.action == "block", 1), else_=0)).label(
+                "blocks"
+            ),
         )
-        .filter(GuardEventDatabase.project_id.in_(project_ids), GuardEventDatabase.date >= thirty_days_ago)
+        .filter(
+            GuardEventDatabase.project_id.in_(project_ids),
+            GuardEventDatabase.date >= thirty_days_ago,
+        )
         .group_by(GuardEventDatabase.project_id)
         .all()
     )
-    guards = {r.project_id: {"total": r.total, "blocks": r.blocks or 0} for r in guard_rows}
+    guards = {
+        r.project_id: {"total": r.total, "blocks": r.blocks or 0} for r in guard_rows
+    }
 
     from sqlalchemy import desc
+
     eval_rows = (
         db_wrapper.db.query(EvalRunDatabase.project_id, EvalRunDatabase.summary)
         .filter(
@@ -236,7 +279,9 @@ async def get_projects_health(
     for r in eval_rows:
         if r.project_id not in evals and r.summary:
             try:
-                summary = _json.loads(r.summary) if isinstance(r.summary, str) else r.summary
+                summary = (
+                    _json.loads(r.summary) if isinstance(r.summary, str) else r.summary
+                )
                 scores = [v for v in summary.values() if isinstance(v, (int, float))]
                 evals[r.project_id] = sum(scores) / len(scores) if scores else None
             except Exception:
@@ -291,16 +336,27 @@ async def get_projects_health(
         else:
             eval_component = 0.5
 
-        health = round((latency_score * 30 + activity_score * 30 + guard_score * 20 + eval_component * 20))
+        health = round(
+            (
+                latency_score * 30
+                + activity_score * 30
+                + guard_score * 20
+                + eval_component * 20
+            )
+        )
 
-        results.append({
-            "project_id": pid,
-            "health": health,
-            "requests_7d": requests_7d,
-            "avg_latency": round(avg_latency) if avg_latency else None,
-            "guard_block_rate": round(block_rate, 3) if block_rate is not None else None,
-            "eval_score": round(eval_score, 2) if eval_score is not None else None,
-        })
+        results.append(
+            {
+                "project_id": pid,
+                "health": health,
+                "requests_7d": requests_7d,
+                "avg_latency": round(avg_latency) if avg_latency else None,
+                "guard_block_rate": (
+                    round(block_rate, 3) if block_rate is not None else None
+                ),
+                "eval_score": round(eval_score, 2) if eval_score is not None else None,
+            }
+        )
 
     return results
 
@@ -383,6 +439,7 @@ async def route_delete_project(
 
         if proj.props.options and proj.props.options.telegram_token:
             from restai.telegram import stop_poller
+
             stop_poller(projectID)
 
         proj.delete()
@@ -397,12 +454,16 @@ async def route_delete_project(
         # — it holds /var/www open via bind mount and racing the wipe empties public/.
         if proj.props.type == "app":
             from restai.app.storage import delete_project_root
+
             mgr = getattr(request.app.state.brain, "app_manager", None)
             if mgr is not None:
                 try:
                     mgr.remove_container(projectID)
                 except Exception:
-                    logging.exception("Failed to stop app container before wipe (project=%s)", projectID)
+                    logging.exception(
+                        "Failed to stop app container before wipe (project=%s)",
+                        projectID,
+                    )
             delete_project_root(projectID)
 
         return {"project": projectID}
@@ -437,19 +498,33 @@ async def route_edit_project(
     if projectModelUpdate.llm and not projectModelUpdate.team_id:
         current_team = db_wrapper.get_team_by_id(project.team_id)
         if current_team:
-            llm_model = request.app.state.brain.get_llm(projectModelUpdate.llm, db_wrapper)
-            if llm_model and llm_model.props.name not in [l.name for l in current_team.llms]:
+            llm_model = request.app.state.brain.get_llm(
+                projectModelUpdate.llm, db_wrapper
+            )
+            if llm_model and llm_model.props.name not in [
+                l.name for l in current_team.llms
+            ]:
                 raise HTTPException(
-                    status_code=403, detail=f"Team does not have access to LLM '{projectModelUpdate.llm}'"
+                    status_code=403,
+                    detail=f"Team does not have access to LLM '{projectModelUpdate.llm}'",
                 )
 
-    if projectModelUpdate.embeddings and not projectModelUpdate.team_id and project.type == "rag":
+    if (
+        projectModelUpdate.embeddings
+        and not projectModelUpdate.team_id
+        and project.type == "rag"
+    ):
         current_team = db_wrapper.get_team_by_id(project.team_id)
         if current_team:
-            embedding_model = request.app.state.brain.get_embedding(projectModelUpdate.embeddings, db_wrapper)
-            if embedding_model and embedding_model.model_name not in [e.name for e in current_team.embeddings]:
+            embedding_model = request.app.state.brain.get_embedding(
+                projectModelUpdate.embeddings, db_wrapper
+            )
+            if embedding_model and embedding_model.model_name not in [
+                e.name for e in current_team.embeddings
+            ]:
                 raise HTTPException(
-                    status_code=403, detail=f"Team does not have access to embedding model '{projectModelUpdate.embeddings}'"
+                    status_code=403,
+                    detail=f"Team does not have access to embedding model '{projectModelUpdate.embeddings}'",
                 )
 
     if projectModelUpdate.team_id:
@@ -503,10 +578,22 @@ async def route_edit_project(
             val = getattr(projectModelUpdate.options, key, None)
             if val and val.startswith("****"):
                 setattr(projectModelUpdate.options, key, existing_opts.get(key))
-        if projectModelUpdate.options.sync_sources and existing_opts.get("sync_sources"):
-            existing_sources = {s.get("name"): s for s in existing_opts["sync_sources"] if isinstance(s, dict)}
+        if projectModelUpdate.options.sync_sources and existing_opts.get(
+            "sync_sources"
+        ):
+            existing_sources = {
+                s.get("name"): s
+                for s in existing_opts["sync_sources"]
+                if isinstance(s, dict)
+            }
             for src in projectModelUpdate.options.sync_sources:
-                for key in ("s3_access_key", "s3_secret_key", "confluence_api_token", "sharepoint_client_secret", "gdrive_service_account_json"):
+                for key in (
+                    "s3_access_key",
+                    "s3_secret_key",
+                    "confluence_api_token",
+                    "sharepoint_client_secret",
+                    "gdrive_service_account_json",
+                ):
                     val = getattr(src, key, None)
                     if val and val.startswith("****"):
                         existing_src = existing_sources.get(src.name, {})
@@ -621,7 +708,11 @@ async def route_create_project(
     ):
         raise HTTPException(status_code=403, detail="Project already exists")
 
-    if projectModel.type != "block" and user.is_private and llm_model.props.privacy != "private":
+    if (
+        projectModel.type != "block"
+        and user.is_private
+        and llm_model.props.privacy != "private"
+    ):
         raise HTTPException(
             status_code=403, detail="User not allowed to use public models"
         )
@@ -658,8 +749,11 @@ async def route_create_project(
 
         if projectModel.type == "app":
             from restai.app.storage import seed_hello_world
+
             try:
-                seed_hello_world(project_db.id, projectModel.human_name or projectModel.name)
+                seed_hello_world(
+                    project_db.id, projectModel.human_name or projectModel.name
+                )
             except Exception:
                 # Don't roll back; user can re-seed by editing any file in the IDE.
                 logging.exception("app seed failed for project %s", project_db.id)
@@ -734,8 +828,14 @@ async def find_embedding(
             try:
                 nodes = retriever.retrieve(embedding.text)
             except Exception as retrieval_err:
-                if "Nothing found on disk" in str(retrieval_err) or "hnsw" in str(retrieval_err).lower():
-                    raise HTTPException(status_code=503, detail="Vector index is being rebuilt. Please try again in a moment.")
+                if (
+                    "Nothing found on disk" in str(retrieval_err)
+                    or "hnsw" in str(retrieval_err).lower()
+                ):
+                    raise HTTPException(
+                        status_code=503,
+                        detail="Vector index is being rebuilt. Please try again in a moment.",
+                    )
                 raise
 
             postprocessor = SimilarityPostprocessor(similarity_cutoff=threshold)
@@ -827,7 +927,11 @@ async def clone_project(
 ):
     """Clone a project with all its settings, eval datasets, and prompt versions."""
     check_not_restricted(user)
-    from restai.models.databasemodels import EvalDatasetDatabase, EvalTestCaseDatabase, PromptVersionDatabase
+    from restai.models.databasemodels import (
+        EvalDatasetDatabase,
+        EvalTestCaseDatabase,
+        PromptVersionDatabase,
+    )
     from datetime import datetime as dt
     from datetime import timezone as tz
 
@@ -841,7 +945,9 @@ async def clone_project(
 
     existing = db_wrapper.get_project_by_name(new_name)
     if existing:
-        raise HTTPException(status_code=409, detail="A project with this name already exists")
+        raise HTTPException(
+            status_code=409, detail="A project with this name already exists"
+        )
 
     new_project = db_wrapper.create_project(
         name=new_name,
@@ -873,15 +979,17 @@ async def clone_project(
         .all()
     )
     for v in source_versions:
-        db_wrapper.db.add(PromptVersionDatabase(
-            project_id=new_project.id,
-            version=v.version,
-            system_prompt=v.system_prompt,
-            description=v.description,
-            created_by=user.id,
-            created_at=dt.now(tz.utc),
-            is_active=v.is_active,
-        ))
+        db_wrapper.db.add(
+            PromptVersionDatabase(
+                project_id=new_project.id,
+                version=v.version,
+                system_prompt=v.system_prompt,
+                description=v.description,
+                created_by=user.id,
+                created_at=dt.now(tz.utc),
+                is_active=v.is_active,
+            )
+        )
 
     source_datasets = (
         db_wrapper.db.query(EvalDatasetDatabase)
@@ -905,13 +1013,15 @@ async def clone_project(
             .all()
         )
         for tc in source_cases:
-            db_wrapper.db.add(EvalTestCaseDatabase(
-                dataset_id=new_ds.id,
-                question=tc.question,
-                expected_answer=tc.expected_answer,
-                context=tc.context,
-                created_at=dt.now(tz.utc),
-            ))
+            db_wrapper.db.add(
+                EvalTestCaseDatabase(
+                    dataset_id=new_ds.id,
+                    question=tc.question,
+                    expected_answer=tc.expected_answer,
+                    context=tc.context,
+                    created_at=dt.now(tz.utc),
+                )
+            )
 
     db_wrapper.db.commit()
 
@@ -919,7 +1029,9 @@ async def clone_project(
 
 
 @router.post(
-    "/projects/{projectID}/embeddings/ingest/text", response_model=IngestResponse, tags=["Knowledge"]
+    "/projects/{projectID}/embeddings/ingest/text",
+    response_model=IngestResponse,
+    tags=["Knowledge"],
 )
 async def ingest_text(
     request: Request,
@@ -957,8 +1069,11 @@ async def ingest_text(
             full_text = "\n".join(d.text for d in documents)
             background_tasks.add_task(
                 extract_and_persist_safe,
-                project.props.id, ingest.source, full_text,
-                request.app.state.brain, DBWrapper,
+                project.props.id,
+                ingest.source,
+                full_text,
+                request.app.state.brain,
+                DBWrapper,
             )
 
         return {
@@ -974,7 +1089,9 @@ async def ingest_text(
 
 
 @router.post(
-    "/projects/{projectID}/embeddings/ingest/url", response_model=IngestResponse, tags=["Knowledge"]
+    "/projects/{projectID}/embeddings/ingest/url",
+    response_model=IngestResponse,
+    tags=["Knowledge"],
 )
 async def ingest_url(
     request: Request,
@@ -995,6 +1112,7 @@ async def ingest_url(
         # SSRF protection — block requests to private/internal networks
         from restai.helper import _is_private_ip
         from urllib.parse import urlparse as _urlparse
+
         try:
             hostname = _urlparse(ingest.url).hostname
         except Exception:
@@ -1016,7 +1134,9 @@ async def ingest_url(
 
         urls = project.vector.list()
         if ingest.url in urls:
-            raise HTTPException(status_code=409, detail="URL already ingested. Delete first.")
+            raise HTTPException(
+                status_code=409, detail="URL already ingested. Delete first."
+            )
 
         loader = SeleniumWebReader()
 
@@ -1034,8 +1154,11 @@ async def ingest_url(
             full_text = "\n".join(d.text for d in documents)
             background_tasks.add_task(
                 extract_and_persist_safe,
-                project.props.id, ingest.url, full_text,
-                request.app.state.brain, DBWrapper,
+                project.props.id,
+                ingest.url,
+                full_text,
+                request.app.state.brain,
+                DBWrapper,
             )
 
         return {"source": ingest.url, "documents": len(documents), "chunks": n_chunks}
@@ -1047,7 +1170,9 @@ async def ingest_url(
 
 
 @router.post(
-    "/projects/{projectID}/embeddings/ingest/upload", response_model=IngestResponse, tags=["Knowledge"]
+    "/projects/{projectID}/embeddings/ingest/upload",
+    response_model=IngestResponse,
+    tags=["Knowledge"],
 )
 async def ingest_file(
     request: Request,
@@ -1065,7 +1190,9 @@ async def ingest_file(
     """Upload and ingest a file into the knowledge base."""
     check_not_restricted(user)
     if splitter not in ("sentence", "token"):
-        raise HTTPException(status_code=422, detail="splitter must be 'sentence' or 'token'")
+        raise HTTPException(
+            status_code=422, detail="splitter must be 'sentence' or 'token'"
+        )
 
     contents = await file.read()
     if len(contents) > config.MAX_UPLOAD_SIZE:
@@ -1089,6 +1216,7 @@ async def ingest_file(
         resolved_method = "classic" if classic else "docling"
 
     from restai.models.models import sanitize_filename
+
     file.filename = sanitize_filename(file.filename)
     ext = os.path.splitext(file.filename)[1].lower()
     source_name = unidecode(file.filename)
@@ -1104,20 +1232,30 @@ async def ingest_file(
 
         if resolved_method == "auto":
             from restai.loaders.markitdown_loader import auto_ingest
+
             documents, used_method = auto_ingest(
-                temp.name, source_name,
+                temp.name,
+                source_name,
                 manager=getattr(request.app.state, "manager", None),
                 opts=opts,
             )
             if not documents:
-                raise HTTPException(status_code=400, detail="No content could be extracted from the file.")
+                raise HTTPException(
+                    status_code=400,
+                    detail="No content could be extracted from the file.",
+                )
         elif resolved_method == "markitdown":
             from restai.loaders.markitdown_loader import load_with_markitdown
+
             documents = load_with_markitdown(temp.name, source=source_name)
             if not documents:
-                raise HTTPException(status_code=400, detail="MarkItDown could not extract content from this file.")
+                raise HTTPException(
+                    status_code=400,
+                    detail="MarkItDown could not extract content from this file.",
+                )
         elif resolved_method == "docling":
             from restai.document.runner import load_documents
+
             documents = load_documents(request.app.state.manager, temp.name)
         else:
             used_method = "classic"
@@ -1145,8 +1283,11 @@ async def ingest_file(
             full_text = "\n".join(d.text for d in documents)
             background_tasks.add_task(
                 extract_and_persist_safe,
-                project.props.id, source_name, full_text,
-                request.app.state.brain, DBWrapper,
+                project.props.id,
+                source_name,
+                full_text,
+                request.app.state.brain,
+                DBWrapper,
             )
 
         return {
@@ -1236,25 +1377,33 @@ async def chat_query(
     """Send a chat message to a project with conversation history."""
     try:
         import time as _time
+
         start_time = _time.perf_counter()
 
         # Resume in-flight stream for the chat_id; honors SSE Last-Event-ID.
+        # Only attach when there's something to resume: the session is still
+        # in-flight, OR the client is genuinely reconnecting (Last-Event-ID
+        # set). A fresh message on a reused chat_id whose prior turn already
+        # finished must NOT replay that turn — it falls through to a new run.
         if q_input.stream and q_input.id:
             from restai import chat_resume as _resume
+
             existing = await _resume.lookup(q_input.id)
             if existing is not None:
-                last_id = 0
                 hdr = request.headers.get("last-event-id")
-                if hdr:
-                    try:
-                        last_id = int(hdr)
-                    except ValueError:
-                        last_id = 0
-                from starlette.responses import StreamingResponse as _SR
-                return _SR(
-                    existing.subscribe(last_event_id=last_id),
-                    media_type="text/event-stream",
-                )
+                if (await existing.is_in_flight()) or hdr:
+                    last_id = 0
+                    if hdr:
+                        try:
+                            last_id = int(hdr)
+                        except ValueError:
+                            last_id = 0
+                    from starlette.responses import StreamingResponse as _SR
+
+                    return _SR(
+                        existing.subscribe(last_event_id=last_id),
+                        media_type="text/event-stream",
+                    )
 
         if not q_input.question and not q_input.image:
             raise HTTPException(status_code=400, detail="Missing question")
@@ -1301,6 +1450,7 @@ async def chat_stop(
         # Enforce same auth scope as /chat (404s cross-project chat_ids).
         get_project(projectID, db_wrapper, request.app.state.brain)
         from restai import chat_resume as _resume
+
         sess = await _resume.lookup(chat_id)
         if sess is None:
             # Evict in case of half-state.
@@ -1332,6 +1482,7 @@ async def question_query_endpoint(
     preserved (`type: "question"`) for backwards compatibility."""
     try:
         import time as _time
+
         start_time = _time.perf_counter()
 
         if not q_input.question and not q_input.image:
@@ -1376,6 +1527,7 @@ async def list_prompt_versions(
 ):
     """List all prompt versions for a project."""
     from restai.models.models import PromptVersionResponse
+
     versions = db_wrapper.get_prompt_versions(projectID)
     return [PromptVersionResponse.model_validate(v) for v in versions]
 
@@ -1389,6 +1541,7 @@ async def get_prompt_version(
 ):
     """Get a specific prompt version."""
     from restai.models.models import PromptVersionResponse
+
     version = db_wrapper.get_prompt_version(versionID)
     if version is None or version.project_id != projectID:
         raise HTTPException(status_code=404, detail="Prompt version not found")
@@ -1414,6 +1567,7 @@ async def activate_prompt_version(
         raise HTTPException(status_code=404, detail="Project not found")
 
     from restai.models.models import ProjectModelUpdate
+
     update = ProjectModelUpdate(system=version.system_prompt)
     update._user_id = user.id
     db_wrapper.edit_project(projectID, update)
@@ -1430,31 +1584,54 @@ async def get_guard_summary(
     """Get guard event summary statistics for a project."""
     from restai.models.databasemodels import GuardEventDatabase
 
-    total = db_wrapper.db.query(func.count(GuardEventDatabase.id)).filter(
-        GuardEventDatabase.project_id == projectID
-    ).scalar() or 0
+    total = (
+        db_wrapper.db.query(func.count(GuardEventDatabase.id))
+        .filter(GuardEventDatabase.project_id == projectID)
+        .scalar()
+        or 0
+    )
 
-    blocks = db_wrapper.db.query(func.count(GuardEventDatabase.id)).filter(
-        GuardEventDatabase.project_id == projectID,
-        GuardEventDatabase.action == "block",
-    ).scalar() or 0
+    blocks = (
+        db_wrapper.db.query(func.count(GuardEventDatabase.id))
+        .filter(
+            GuardEventDatabase.project_id == projectID,
+            GuardEventDatabase.action == "block",
+        )
+        .scalar()
+        or 0
+    )
 
-    warns = db_wrapper.db.query(func.count(GuardEventDatabase.id)).filter(
-        GuardEventDatabase.project_id == projectID,
-        GuardEventDatabase.action == "warn",
-    ).scalar() or 0
+    warns = (
+        db_wrapper.db.query(func.count(GuardEventDatabase.id))
+        .filter(
+            GuardEventDatabase.project_id == projectID,
+            GuardEventDatabase.action == "warn",
+        )
+        .scalar()
+        or 0
+    )
 
-    input_blocks = db_wrapper.db.query(func.count(GuardEventDatabase.id)).filter(
-        GuardEventDatabase.project_id == projectID,
-        GuardEventDatabase.action.in_(["block", "warn"]),
-        GuardEventDatabase.phase == "input",
-    ).scalar() or 0
+    input_blocks = (
+        db_wrapper.db.query(func.count(GuardEventDatabase.id))
+        .filter(
+            GuardEventDatabase.project_id == projectID,
+            GuardEventDatabase.action.in_(["block", "warn"]),
+            GuardEventDatabase.phase == "input",
+        )
+        .scalar()
+        or 0
+    )
 
-    output_blocks = db_wrapper.db.query(func.count(GuardEventDatabase.id)).filter(
-        GuardEventDatabase.project_id == projectID,
-        GuardEventDatabase.action.in_(["block", "warn"]),
-        GuardEventDatabase.phase == "output",
-    ).scalar() or 0
+    output_blocks = (
+        db_wrapper.db.query(func.count(GuardEventDatabase.id))
+        .filter(
+            GuardEventDatabase.project_id == projectID,
+            GuardEventDatabase.action.in_(["block", "warn"]),
+            GuardEventDatabase.phase == "output",
+        )
+        .scalar()
+        or 0
+    )
 
     return {
         "total_checks": total,
@@ -1493,8 +1670,12 @@ async def get_guard_daily(
         db_wrapper.db.query(
             func.date(GuardEventDatabase.date).label("date"),
             func.count(GuardEventDatabase.id).label("checks"),
-            func.sum(case((GuardEventDatabase.action == "block", 1), else_=0)).label("blocks"),
-            func.sum(case((GuardEventDatabase.action == "warn", 1), else_=0)).label("warns"),
+            func.sum(case((GuardEventDatabase.action == "block", 1), else_=0)).label(
+                "blocks"
+            ),
+            func.sum(case((GuardEventDatabase.action == "warn", 1), else_=0)).label(
+                "warns"
+            ),
         )
         .filter(
             GuardEventDatabase.project_id == projectID,
@@ -1541,7 +1722,12 @@ async def get_guard_events(
         query = query.filter(GuardEventDatabase.action == action)
 
     total = query.count()
-    events = query.order_by(GuardEventDatabase.date.desc()).offset(start).limit(end - start).all()
+    events = (
+        query.order_by(GuardEventDatabase.date.desc())
+        .offset(start)
+        .limit(end - start)
+        .all()
+    )
 
     return {
         "events": [GuardEventResponse.model_validate(e) for e in events],
@@ -1563,7 +1749,9 @@ async def get_source_analytics(
 
     project = get_project(projectID, db_wrapper, request.app.state.brain)
     if project.props.type != "rag":
-        raise HTTPException(status_code=400, detail="Source analytics only available for RAG projects")
+        raise HTTPException(
+            status_code=400, detail="Source analytics only available for RAG projects"
+        )
 
     since = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=days)
 
@@ -1628,7 +1816,9 @@ async def get_chunking_analytics(
 
     project = get_project(projectID, db_wrapper, request.app.state.brain)
     if project.props.type != "rag":
-        raise HTTPException(status_code=400, detail="Chunking analytics only available for RAG projects")
+        raise HTTPException(
+            status_code=400, detail="Chunking analytics only available for RAG projects"
+        )
 
     MAX_CHUNKS = 50000
     truncated = False
@@ -1669,7 +1859,9 @@ async def get_chunking_analytics(
     total_chunks_count = len(chunk_token_lengths)
     avg_chunk_tokens = round(sum(chunk_token_lengths) / max(total_chunks_count, 1))
     sorted_lengths = sorted(chunk_token_lengths)
-    median_chunk_tokens = sorted_lengths[total_chunks_count // 2] if sorted_lengths else 0
+    median_chunk_tokens = (
+        sorted_lengths[total_chunks_count // 2] if sorted_lengths else 0
+    )
 
     since = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=days)
 
@@ -1702,27 +1894,52 @@ async def get_chunking_analytics(
         low, high = buckets[i], buckets[i + 1]
         count = sum(1 for tl in retrieved_token_lengths if low <= tl < high)
         ret_bucket_counts.append(count)
-    ret_bucket_counts.append(sum(1 for tl in retrieved_token_lengths if tl >= buckets[-1]))
+    ret_bucket_counts.append(
+        sum(1 for tl in retrieved_token_lengths if tl >= buckets[-1])
+    )
 
-    avg_retrieved_tokens = round(sum(retrieved_token_lengths) / max(len(retrieved_token_lengths), 1)) if retrieved_token_lengths else None
-    avg_score = round(sum(retrieved_scores) / max(len(retrieved_scores), 1), 3) if retrieved_scores else None
+    avg_retrieved_tokens = (
+        round(sum(retrieved_token_lengths) / max(len(retrieved_token_lengths), 1))
+        if retrieved_token_lengths
+        else None
+    )
+    avg_score = (
+        round(sum(retrieved_scores) / max(len(retrieved_scores), 1), 3)
+        if retrieved_scores
+        else None
+    )
 
     score_by_bucket = []
     for i in range(len(buckets) - 1):
         low, high = buckets[i], buckets[i + 1]
         scores_in_bucket = [
-            row.score for row in retrieval_rows
-            if row.chunk_token_length and low <= row.chunk_token_length < high and row.score is not None
+            row.score
+            for row in retrieval_rows
+            if row.chunk_token_length
+            and low <= row.chunk_token_length < high
+            and row.score is not None
         ]
-        score_by_bucket.append({
-            "bucket": f"{low}-{high}",
-            "avg_score": round(sum(scores_in_bucket) / len(scores_in_bucket), 3) if scores_in_bucket else None,
-            "count": len(scores_in_bucket),
-        })
+        score_by_bucket.append(
+            {
+                "bucket": f"{low}-{high}",
+                "avg_score": (
+                    round(sum(scores_in_bucket) / len(scores_in_bucket), 3)
+                    if scores_in_bucket
+                    else None
+                ),
+                "count": len(scores_in_bucket),
+            }
+        )
 
     all_chunk_ids = {c["id"] for c in all_chunks}
-    never_retrieved_chunks = len(all_chunk_ids - retrieved_chunk_ids) if all_chunk_ids else 0
-    retrieval_rate = round(len(retrieved_chunk_ids) / max(len(all_chunk_ids), 1), 3) if all_chunk_ids else 0
+    never_retrieved_chunks = (
+        len(all_chunk_ids - retrieved_chunk_ids) if all_chunk_ids else 0
+    )
+    retrieval_rate = (
+        round(len(retrieved_chunk_ids) / max(len(all_chunk_ids), 1), 3)
+        if all_chunk_ids
+        else 0
+    )
 
     recommendations = []
 
@@ -1730,38 +1947,44 @@ async def get_chunking_analytics(
         ratio = avg_retrieved_tokens / avg_chunk_tokens
         if ratio < 0.7:
             suggested = _nearest_chunk_size(avg_retrieved_tokens)
-            recommendations.append({
-                "type": "reduce_chunk_size",
-                "severity": "high" if ratio < 0.5 else "medium",
-                "message": (
-                    f"Your average chunk is {avg_chunk_tokens} tokens, but retrieved chunks "
-                    f"average {avg_retrieved_tokens} tokens. Consider using {suggested}-token chunks "
-                    f"for better precision."
-                ),
-                "suggested_chunk_size": suggested,
-            })
+            recommendations.append(
+                {
+                    "type": "reduce_chunk_size",
+                    "severity": "high" if ratio < 0.5 else "medium",
+                    "message": (
+                        f"Your average chunk is {avg_chunk_tokens} tokens, but retrieved chunks "
+                        f"average {avg_retrieved_tokens} tokens. Consider using {suggested}-token chunks "
+                        f"for better precision."
+                    ),
+                    "suggested_chunk_size": suggested,
+                }
+            )
         elif ratio > 1.3:
             suggested = _nearest_chunk_size(avg_retrieved_tokens)
-            recommendations.append({
-                "type": "increase_chunk_size",
-                "severity": "medium",
-                "message": (
-                    f"Retrieved chunks average {avg_retrieved_tokens} tokens, larger than your "
-                    f"typical chunk of {avg_chunk_tokens} tokens. Consider increasing to "
-                    f"{suggested} tokens for more context per retrieval."
-                ),
-                "suggested_chunk_size": suggested,
-            })
+            recommendations.append(
+                {
+                    "type": "increase_chunk_size",
+                    "severity": "medium",
+                    "message": (
+                        f"Retrieved chunks average {avg_retrieved_tokens} tokens, larger than your "
+                        f"typical chunk of {avg_chunk_tokens} tokens. Consider increasing to "
+                        f"{suggested} tokens for more context per retrieval."
+                    ),
+                    "suggested_chunk_size": suggested,
+                }
+            )
 
     if retrieval_rate < 0.3 and total_chunks_count > 10:
-        recommendations.append({
-            "type": "low_retrieval_rate",
-            "severity": "medium",
-            "message": (
-                f"Only {round(retrieval_rate * 100)}% of chunks have been retrieved in the last "
-                f"{days} days. Many chunks may be redundant or poorly sized."
-            ),
-        })
+        recommendations.append(
+            {
+                "type": "low_retrieval_rate",
+                "severity": "medium",
+                "message": (
+                    f"Only {round(retrieval_rate * 100)}% of chunks have been retrieved in the last "
+                    f"{days} days. Many chunks may be redundant or poorly sized."
+                ),
+            }
+        )
 
     best_bucket = max(
         (b for b in score_by_bucket if b["avg_score"] is not None and b["count"] >= 3),
@@ -1769,14 +1992,16 @@ async def get_chunking_analytics(
         default=None,
     )
     if best_bucket:
-        recommendations.append({
-            "type": "best_scoring_range",
-            "severity": "info",
-            "message": (
-                f"Chunks in the {best_bucket['bucket']} token range have the highest average "
-                f"retrieval score ({best_bucket['avg_score']}). Consider targeting this range."
-            ),
-        })
+        recommendations.append(
+            {
+                "type": "best_scoring_range",
+                "severity": "info",
+                "message": (
+                    f"Chunks in the {best_bucket['bucket']} token range have the highest average "
+                    f"retrieval score ({best_bucket['avg_score']}). Consider targeting this range."
+                ),
+            }
+        )
 
     return {
         "total_chunks": total_chunks_count,
@@ -1816,12 +2041,15 @@ async def trigger_sync(
     check_not_restricted(user)
     project = get_project(projectID, db_wrapper, request.app.state.brain)
     if project.props.type != "rag":
-        raise HTTPException(status_code=400, detail="Sync only available for RAG projects")
+        raise HTTPException(
+            status_code=400, detail="Sync only available for RAG projects"
+        )
     opts = project.props.options
     if not opts or not opts.sync_sources:
         raise HTTPException(status_code=400, detail="No sync sources configured")
 
     from restai.sync import run_sync_now
+
     run_sync_now(projectID, request.app.state.brain)
     return {"message": "Sync triggered"}
 
@@ -1871,22 +2099,46 @@ async def get_conversation_analytics(
         OutputDatabase.date <= end_date,
     ]
 
-    total_messages = db_wrapper.db.query(func.count(OutputDatabase.id)).filter(*base_filter).scalar() or 0
-    total_conversations = db_wrapper.db.query(func.count(func.distinct(OutputDatabase.chat_id))).filter(
-        *base_filter, OutputDatabase.chat_id.isnot(None)
-    ).scalar() or 0
-    avg_latency = db_wrapper.db.query(func.avg(OutputDatabase.latency_ms)).filter(*base_filter).scalar()
-    total_tokens = db_wrapper.db.query(
-        func.sum(OutputDatabase.input_tokens + OutputDatabase.output_tokens)
-    ).filter(*base_filter).scalar() or 0
-    total_cost = db_wrapper.db.query(
-        func.sum(OutputDatabase.input_cost + OutputDatabase.output_cost)
-    ).filter(*base_filter).scalar() or 0
+    total_messages = (
+        db_wrapper.db.query(func.count(OutputDatabase.id)).filter(*base_filter).scalar()
+        or 0
+    )
+    total_conversations = (
+        db_wrapper.db.query(func.count(func.distinct(OutputDatabase.chat_id)))
+        .filter(*base_filter, OutputDatabase.chat_id.isnot(None))
+        .scalar()
+        or 0
+    )
+    avg_latency = (
+        db_wrapper.db.query(func.avg(OutputDatabase.latency_ms))
+        .filter(*base_filter)
+        .scalar()
+    )
+    total_tokens = (
+        db_wrapper.db.query(
+            func.sum(OutputDatabase.input_tokens + OutputDatabase.output_tokens)
+        )
+        .filter(*base_filter)
+        .scalar()
+        or 0
+    )
+    total_cost = (
+        db_wrapper.db.query(
+            func.sum(OutputDatabase.input_cost + OutputDatabase.output_cost)
+        )
+        .filter(*base_filter)
+        .scalar()
+        or 0
+    )
 
     summary = {
         "total_conversations": total_conversations,
         "total_messages": total_messages,
-        "avg_messages_per_conversation": round(total_messages / total_conversations, 1) if total_conversations > 0 else 0,
+        "avg_messages_per_conversation": (
+            round(total_messages / total_conversations, 1)
+            if total_conversations > 0
+            else 0
+        ),
         "avg_latency_ms": round(avg_latency) if avg_latency else 0,
         "total_tokens": total_tokens,
         "total_cost": round(total_cost, 4),
@@ -1903,7 +2155,10 @@ async def get_conversation_analytics(
         .order_by(func.date(OutputDatabase.date))
         .all()
     )
-    daily = [{"date": r.date, "conversations": r.conversations, "messages": r.messages} for r in daily_rows]
+    daily = [
+        {"date": r.date, "conversations": r.conversations, "messages": r.messages}
+        for r in daily_rows
+    ]
 
     hourly_rows = (
         db_wrapper.db.query(
@@ -1931,7 +2186,10 @@ async def get_conversation_analytics(
         .limit(10)
         .all()
     )
-    top_users = [{"user_id": r.user_id, "username": r.username, "messages": r.messages} for r in top_user_rows]
+    top_users = [
+        {"user_id": r.user_id, "username": r.username, "messages": r.messages}
+        for r in top_user_rows
+    ]
 
     status_rows = (
         db_wrapper.db.query(
@@ -1942,7 +2200,9 @@ async def get_conversation_analytics(
         .group_by(OutputDatabase.status)
         .all()
     )
-    status_breakdown = [{"status": (r.status or "success"), "count": r.count} for r in status_rows]
+    status_breakdown = [
+        {"status": (r.status or "success"), "count": r.count} for r in status_rows
+    ]
 
     LATENCY_BUCKETS = [
         ("0-100ms", 0, 100),
@@ -1966,8 +2226,12 @@ async def get_conversation_analytics(
         db_wrapper.db.query(
             OutputDatabase.llm,
             func.count(OutputDatabase.id).label("messages"),
-            func.sum(OutputDatabase.input_tokens + OutputDatabase.output_tokens).label("tokens"),
-            func.sum(OutputDatabase.input_cost + OutputDatabase.output_cost).label("cost"),
+            func.sum(OutputDatabase.input_tokens + OutputDatabase.output_tokens).label(
+                "tokens"
+            ),
+            func.sum(OutputDatabase.input_cost + OutputDatabase.output_cost).label(
+                "cost"
+            ),
         )
         .filter(*base_filter, OutputDatabase.llm.isnot(None))
         .group_by(OutputDatabase.llm)
@@ -2069,8 +2333,18 @@ async def get_conversation_replay(
 @router.get("/projects/{projectID}/tokens/daily", tags=["Statistics"])
 async def get_monthly_token_consumption(
     projectID: int = PathParam(description="Project ID"),
-    year: int = Query(None, ge=2000, le=2100, description="Year for the report (defaults to current year)"),
-    month: int = Query(None, ge=1, le=12, description="Month for the report (defaults to current month)"),
+    year: int = Query(
+        None,
+        ge=2000,
+        le=2100,
+        description="Year for the report (defaults to current year)",
+    ),
+    month: int = Query(
+        None,
+        ge=1,
+        le=12,
+        description="Month for the report (defaults to current month)",
+    ),
     _: User = Depends(get_current_username_project),
     db_wrapper: DBWrapper = Depends(get_db_wrapper),
 ):
@@ -2118,7 +2392,9 @@ async def get_monthly_token_consumption(
                     "output_tokens": tc.output_tokens,
                     "input_cost": tc.input_cost,
                     "output_cost": tc.output_cost,
-                    "avg_latency_ms": round(tc.avg_latency_ms) if tc.avg_latency_ms else 0,
+                    "avg_latency_ms": (
+                        round(tc.avg_latency_ms) if tc.avg_latency_ms else 0
+                    ),
                 }
                 for tc in token_consumptions
             ]
@@ -2128,7 +2404,6 @@ async def get_monthly_token_consumption(
             raise e
         logging.exception(e)
         raise HTTPException(status_code=500, detail="Internal server error")
-
 
 
 @router.get("/projects/{projectID}/comments", tags=["Comments"])
@@ -2199,10 +2474,14 @@ async def update_project_comment(
     from restai.models.databasemodels import ProjectCommentDatabase
     from datetime import datetime, timezone
 
-    comment = db_wrapper.db.query(ProjectCommentDatabase).filter(
-        ProjectCommentDatabase.id == commentID,
-        ProjectCommentDatabase.project_id == projectID,
-    ).first()
+    comment = (
+        db_wrapper.db.query(ProjectCommentDatabase)
+        .filter(
+            ProjectCommentDatabase.id == commentID,
+            ProjectCommentDatabase.project_id == projectID,
+        )
+        .first()
+    )
     if not comment:
         raise HTTPException(status_code=404, detail="Comment not found")
     if comment.user_id != user.id and not user.is_admin:
@@ -2225,10 +2504,14 @@ async def delete_project_comment(
     check_not_restricted(user)
     from restai.models.databasemodels import ProjectCommentDatabase
 
-    comment = db_wrapper.db.query(ProjectCommentDatabase).filter(
-        ProjectCommentDatabase.id == commentID,
-        ProjectCommentDatabase.project_id == projectID,
-    ).first()
+    comment = (
+        db_wrapper.db.query(ProjectCommentDatabase)
+        .filter(
+            ProjectCommentDatabase.id == commentID,
+            ProjectCommentDatabase.project_id == projectID,
+        )
+        .first()
+    )
     if not comment:
         raise HTTPException(status_code=404, detail="Comment not found")
     if comment.user_id != user.id and not user.is_admin:
@@ -2308,8 +2591,6 @@ async def get_project_tools(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-
-
 @router.post("/projects/{projectID}/invitations", tags=["Projects"])
 async def send_project_invitation(
     projectID: int = PathParam(description="Project ID"),
@@ -2324,9 +2605,13 @@ async def send_project_invitation(
     if project_db is None:
         raise HTTPException(status_code=404, detail="Project not found")
     if not user.is_admin and project_db.creator != user.id:
-        raise HTTPException(status_code=403, detail="Only the project creator can invite users")
+        raise HTTPException(
+            status_code=403, detail="Only the project creator can invite users"
+        )
 
-    response = {"message": "If the user exists and belongs to the team, they will receive the invitation."}
+    response = {
+        "message": "If the user exists and belongs to the team, they will receive the invitation."
+    }
 
     username = body.get("username", "").strip()
     if not username:
@@ -2368,8 +2653,6 @@ async def send_project_invitation(
     db_wrapper.db.commit()
 
     return response
-
-
 
 
 @router.post("/projects/{projectID}/widgets", status_code=201, tags=["Widgets"])
@@ -2467,7 +2750,9 @@ async def update_widget(
     return WidgetResponse.model_validate(widget)
 
 
-@router.delete("/projects/{projectID}/widgets/{widgetID}", status_code=204, tags=["Widgets"])
+@router.delete(
+    "/projects/{projectID}/widgets/{widgetID}", status_code=204, tags=["Widgets"]
+)
 async def delete_widget(
     projectID: int = PathParam(description="Project ID"),
     widgetID: int = PathParam(description="Widget ID"),
@@ -2482,7 +2767,9 @@ async def delete_widget(
     db_wrapper.delete_widget(widget)
 
 
-@router.post("/projects/{projectID}/widgets/{widgetID}/regenerate-key", tags=["Widgets"])
+@router.post(
+    "/projects/{projectID}/widgets/{widgetID}/regenerate-key", tags=["Widgets"]
+)
 async def regenerate_widget_key(
     projectID: int = PathParam(description="Project ID"),
     widgetID: int = PathParam(description="Widget ID"),
@@ -2508,7 +2795,9 @@ async def regenerate_widget_key(
     return resp
 
 
-@router.post("/projects/{projectID}/widgets/{widgetID}/context-secret", tags=["Widgets"])
+@router.post(
+    "/projects/{projectID}/widgets/{widgetID}/context-secret", tags=["Widgets"]
+)
 async def generate_widget_context_secret(
     projectID: int = PathParam(description="Project ID"),
     widgetID: int = PathParam(description="Widget ID"),
@@ -2530,7 +2819,9 @@ async def generate_widget_context_secret(
     return {"context_secret": plaintext_secret}
 
 
-@router.delete("/projects/{projectID}/widgets/{widgetID}/context-secret", tags=["Widgets"])
+@router.delete(
+    "/projects/{projectID}/widgets/{widgetID}/context-secret", tags=["Widgets"]
+)
 async def remove_widget_context_secret(
     projectID: int = PathParam(description="Project ID"),
     widgetID: int = PathParam(description="Widget ID"),
@@ -2621,6 +2912,7 @@ async def update_routine(
         raise HTTPException(status_code=404, detail="Routine not found")
 
     from datetime import datetime, timezone
+
     if body.name is not None:
         routine.name = body.name
     if body.message is not None:
@@ -2641,7 +2933,9 @@ async def update_routine(
     }
 
 
-@router.delete("/projects/{projectID}/routines/{routineID}", tags=["Routines"], status_code=204)
+@router.delete(
+    "/projects/{projectID}/routines/{routineID}", tags=["Routines"], status_code=204
+)
 async def delete_routine(
     projectID: int = PathParam(description="Project ID"),
     routineID: int = PathParam(description="Routine ID"),
@@ -2681,7 +2975,13 @@ async def fire_routine(
     background_tasks = BackgroundTasks()
 
     result = await chat_main(
-        request, brain, project, q, user, db_wrapper, background_tasks,
+        request,
+        brain,
+        project,
+        q,
+        user,
+        db_wrapper,
+        background_tasks,
     )
 
     for task in background_tasks.tasks:
@@ -2694,6 +2994,7 @@ async def fire_routine(
             pass
 
     from datetime import datetime, timezone
+
     answer = result.get("answer", "") if isinstance(result, dict) else str(result)
     routine.last_run = datetime.now(timezone.utc)
     routine.last_result = answer[:2000] if answer else None
@@ -2703,12 +3004,18 @@ async def fire_routine(
     # Manual-fire row in the execution log; `manual=True` distinguishes from cron.
     try:
         from restai.models.databasemodels import RoutineExecutionLogDatabase
-        db_wrapper.db.add(RoutineExecutionLogDatabase(
-            routine_id=routine.id, project_id=routine.project_id,
-            status="ok", result=(answer[:2000] if answer else None),
-            duration_ms=None, is_manual=True,
-            created_at=datetime.now(timezone.utc),
-        ))
+
+        db_wrapper.db.add(
+            RoutineExecutionLogDatabase(
+                routine_id=routine.id,
+                project_id=routine.project_id,
+                status="ok",
+                result=(answer[:2000] if answer else None),
+                duration_ms=None,
+                is_manual=True,
+                created_at=datetime.now(timezone.utc),
+            )
+        )
         db_wrapper.db.commit()
     except Exception:
         logging.exception("Failed to write routine execution log row for manual fire")
@@ -2726,6 +3033,7 @@ async def get_routine_history(
 ):
     """Recent execution history for a routine, newest first."""
     from restai.models.databasemodels import RoutineExecutionLogDatabase
+
     routine = db_wrapper.get_project_routine_by_id(routineID)
     if not routine or routine.project_id != projectID:
         raise HTTPException(status_code=404, detail="Routine not found")
@@ -2759,6 +3067,7 @@ async def list_memory_bank(
 ):
     """Visualizer payload: entries grouped by granularity + aggregate stats."""
     from restai.models.databasemodels import ProjectMemoryBankEntryDatabase
+
     project = db_wrapper.get_project_by_id(projectID)
     if not project:
         raise HTTPException(status_code=404, detail="Project not found")
@@ -2781,7 +3090,9 @@ async def list_memory_bank(
             "summary": r.summary or "",
             "token_count": r.token_count or 0,
             "source_message_count": r.source_message_count or 0,
-            "last_source_at": r.last_source_at.isoformat() if r.last_source_at else None,
+            "last_source_at": (
+                r.last_source_at.isoformat() if r.last_source_at else None
+            ),
             "created_at": r.created_at.isoformat() if r.created_at else None,
             "updated_at": r.updated_at.isoformat() if r.updated_at else None,
         }
@@ -2819,8 +3130,10 @@ async def preview_memory_bank(
     options = json.loads(project.options) if project.options else {}
     max_tokens = int(options.get("memory_bank_max_tokens") or 2000)
     from restai import memory_bank
+
     block = memory_bank.render_for_prompt(db_wrapper, projectID, max_tokens)
     from restai.tools import tokens_from_string
+
     return {
         "block": block,
         "tokens": tokens_from_string(block) if block else 0,
@@ -2850,6 +3163,7 @@ async def memory_search_query(
         k = 5
 
     from restai.llms.tools.search_memories import search_memories
+
     brain = request.app.state.brain
     result = search_memories(
         query=query,
@@ -2870,6 +3184,7 @@ async def clear_memory_bank(
     conversations from `OutputDatabase` on the next tick."""
     check_not_restricted(user)
     from restai.models.databasemodels import ProjectMemoryBankEntryDatabase
+
     deleted = (
         db_wrapper.db.query(ProjectMemoryBankEntryDatabase)
         .filter(ProjectMemoryBankEntryDatabase.project_id == projectID)
@@ -2917,6 +3232,7 @@ async def toggle_project_custom_tool(
     if not tool:
         raise HTTPException(status_code=404, detail="Tool not found")
     from datetime import datetime, timezone
+
     tool.enabled = not tool.enabled
     tool.updated_at = datetime.now(timezone.utc)
     db_wrapper.db.commit()
@@ -2938,8 +3254,12 @@ async def update_project_custom_tool(
     if not tool:
         raise HTTPException(status_code=404, detail="Tool not found")
 
-    final_description = body.description if body.description is not None else tool.description
-    final_parameters = body.parameters if body.parameters is not None else tool.parameters
+    final_description = (
+        body.description if body.description is not None else tool.description
+    )
+    final_parameters = (
+        body.parameters if body.parameters is not None else tool.parameters
+    )
     final_code = body.code if body.code is not None else tool.code
 
     if not final_description or not final_description.strip():
@@ -2948,7 +3268,11 @@ async def update_project_custom_tool(
         raise HTTPException(status_code=400, detail="Code is required.")
 
     try:
-        params_dict = json.loads(final_parameters) if isinstance(final_parameters, str) else final_parameters
+        params_dict = (
+            json.loads(final_parameters)
+            if isinstance(final_parameters, str)
+            else final_parameters
+        )
     except json.JSONDecodeError as e:
         raise HTTPException(status_code=400, detail=f"Invalid parameters JSON: {e}")
 
@@ -2956,13 +3280,19 @@ async def update_project_custom_tool(
     warning = None
     if getattr(brain, "docker_manager", None):
         script = f"import json, sys\nargs = json.loads(sys.stdin.readline() or '{{}}')\n{final_code}"
-        test_result = brain.docker_manager.run_script("ephemeral", script, stdin_data="{}")
+        test_result = brain.docker_manager.run_script(
+            "ephemeral", script, stdin_data="{}"
+        )
         if test_result.startswith("ERROR:"):
-            raise HTTPException(status_code=400, detail=f"Code validation failed — {test_result}")
+            raise HTTPException(
+                status_code=400, detail=f"Code validation failed — {test_result}"
+            )
     else:
         warning = "Docker is not configured; code was saved without sandbox validation."
 
-    final_params_str = json.dumps(params_dict) if isinstance(params_dict, dict) else final_parameters
+    final_params_str = (
+        json.dumps(params_dict) if isinstance(params_dict, dict) else final_parameters
+    )
     db_wrapper.upsert_project_tool(
         project_id=projectID,
         name=toolName,
@@ -3014,19 +3344,26 @@ async def block_generate_workspace(
 
     project = get_project(projectID, db_wrapper, request.app.state.brain)
     if project.props.type != "block":
-        raise HTTPException(status_code=400, detail="Only block projects support workspace generation.")
+        raise HTTPException(
+            status_code=400, detail="Only block projects support workspace generation."
+        )
 
     # Names of projects the user can call (for valid restai_call_project blocks).
     all_projects = db_wrapper.db.query(ProjectDatabase).all()
     available_projects = [
-        p.name for p in all_projects
+        p.name
+        for p in all_projects
         if p.id != projectID and (user.is_admin or p.id in user.get_project_ids())
     ]
 
     from restai.utils.blockly_ai import generate_workspace_from_description
+
     try:
         workspace = await generate_workspace_from_description(
-            request.app.state.brain, db_wrapper, body.description, available_projects,
+            request.app.state.brain,
+            db_wrapper,
+            body.description,
+            available_projects,
         )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
@@ -3049,9 +3386,13 @@ async def generate_system_prompt_endpoint(
     project_type = body.project_type or project.props.type
 
     from restai.utils.prompt_ai import generate_system_prompt
+
     try:
         text = await generate_system_prompt(
-            request.app.state.brain, db_wrapper, body.description, project_type,
+            request.app.state.brain,
+            db_wrapper,
+            body.description,
+            project_type,
         )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
@@ -3059,13 +3400,13 @@ async def generate_system_prompt_endpoint(
     return {"system_prompt": text}
 
 
-
-
 @router.get("/projects/{projectID}/kg/entities", tags=["Knowledge Graph"])
 async def kg_list_entities(
     request: Request,
     projectID: int = PathParam(description="Project ID"),
-    type: Optional[str] = Query(None, description="Filter by entity type (PERSON, ORG, LOC, MISC)"),
+    type: Optional[str] = Query(
+        None, description="Filter by entity type (PERSON, ORG, LOC, MISC)"
+    ),
     search: Optional[str] = Query(None, description="Substring search on entity name"),
     limit: int = Query(50, ge=1, le=500),
     offset: int = Query(0, ge=0),
@@ -3077,15 +3418,25 @@ async def kg_list_entities(
 
     project = get_project(projectID, db_wrapper, request.app.state.brain)
     if project.props.type != "rag":
-        raise HTTPException(status_code=400, detail="Knowledge graph is only available for RAG projects.")
+        raise HTTPException(
+            status_code=400,
+            detail="Knowledge graph is only available for RAG projects.",
+        )
 
-    q = db_wrapper.db.query(KGEntityDatabase).filter(KGEntityDatabase.project_id == projectID)
+    q = db_wrapper.db.query(KGEntityDatabase).filter(
+        KGEntityDatabase.project_id == projectID
+    )
     if type:
         q = q.filter(KGEntityDatabase.entity_type == type)
     if search:
         q = q.filter(KGEntityDatabase.normalized.ilike(f"%{search.lower()}%"))
     total = q.count()
-    rows = q.order_by(KGEntityDatabase.mention_count.desc()).offset(offset).limit(limit).all()
+    rows = (
+        q.order_by(KGEntityDatabase.mention_count.desc())
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
     return {
         "total": total,
         "entities": [
@@ -3112,11 +3463,17 @@ async def kg_get_entity(
     db_wrapper: DBWrapper = Depends(get_db_wrapper),
 ):
     """Get one entity with all its mentions and related entities."""
-    from restai.models.databasemodels import KGEntityDatabase, KGEntityMentionDatabase, KGEntityRelationshipDatabase
+    from restai.models.databasemodels import (
+        KGEntityDatabase,
+        KGEntityMentionDatabase,
+        KGEntityRelationshipDatabase,
+    )
 
     entity = (
         db_wrapper.db.query(KGEntityDatabase)
-        .filter(KGEntityDatabase.id == entity_id, KGEntityDatabase.project_id == projectID)
+        .filter(
+            KGEntityDatabase.id == entity_id, KGEntityDatabase.project_id == projectID
+        )
         .first()
     )
     if not entity:
@@ -3142,8 +3499,11 @@ async def kg_get_entity(
         if edge.to_entity_id != entity_id:
             related_ids.add(edge.to_entity_id)
     related_entities = (
-        db_wrapper.db.query(KGEntityDatabase).filter(KGEntityDatabase.id.in_(related_ids)).all()
-        if related_ids else []
+        db_wrapper.db.query(KGEntityDatabase)
+        .filter(KGEntityDatabase.id.in_(related_ids))
+        .all()
+        if related_ids
+        else []
     )
     related_map = {r.id: r for r in related_entities}
 
@@ -3154,8 +3514,7 @@ async def kg_get_entity(
         "entity_type": entity.entity_type,
         "mention_count": entity.mention_count,
         "mentions": [
-            {"source": m.source, "mention_count": m.mention_count}
-            for m in mentions
+            {"source": m.source, "mention_count": m.mention_count} for m in mentions
         ],
         "related": [
             {
@@ -3163,11 +3522,16 @@ async def kg_get_entity(
                 "name": related_map[eid].name,
                 "entity_type": related_map[eid].entity_type,
                 "weight": next(
-                    (e.weight for e in edges if e.from_entity_id == eid or e.to_entity_id == eid),
+                    (
+                        e.weight
+                        for e in edges
+                        if e.from_entity_id == eid or e.to_entity_id == eid
+                    ),
                     1,
                 ),
             }
-            for eid in related_ids if eid in related_map
+            for eid in related_ids
+            if eid in related_map
         ],
     }
 
@@ -3192,7 +3556,9 @@ async def kg_update_entity(
 
     entity = (
         db_wrapper.db.query(KGEntityDatabase)
-        .filter(KGEntityDatabase.id == entity_id, KGEntityDatabase.project_id == projectID)
+        .filter(
+            KGEntityDatabase.id == entity_id, KGEntityDatabase.project_id == projectID
+        )
         .first()
     )
     if not entity:
@@ -3204,7 +3570,11 @@ async def kg_update_entity(
     return {"id": entity.id, "name": entity.name, "normalized": entity.normalized}
 
 
-@router.delete("/projects/{projectID}/kg/entities/{entity_id}", status_code=204, tags=["Knowledge Graph"])
+@router.delete(
+    "/projects/{projectID}/kg/entities/{entity_id}",
+    status_code=204,
+    tags=["Knowledge Graph"],
+)
 async def kg_delete_entity(
     request: Request,
     projectID: int = PathParam(description="Project ID"),
@@ -3214,17 +3584,25 @@ async def kg_delete_entity(
 ):
     """Delete an entity and all its mentions/relationships."""
     check_not_restricted(user)
-    from restai.models.databasemodels import KGEntityDatabase, KGEntityMentionDatabase, KGEntityRelationshipDatabase
+    from restai.models.databasemodels import (
+        KGEntityDatabase,
+        KGEntityMentionDatabase,
+        KGEntityRelationshipDatabase,
+    )
 
     entity = (
         db_wrapper.db.query(KGEntityDatabase)
-        .filter(KGEntityDatabase.id == entity_id, KGEntityDatabase.project_id == projectID)
+        .filter(
+            KGEntityDatabase.id == entity_id, KGEntityDatabase.project_id == projectID
+        )
         .first()
     )
     if not entity:
         raise HTTPException(status_code=404, detail="Entity not found")
 
-    db_wrapper.db.query(KGEntityMentionDatabase).filter(KGEntityMentionDatabase.entity_id == entity_id).delete()
+    db_wrapper.db.query(KGEntityMentionDatabase).filter(
+        KGEntityMentionDatabase.entity_id == entity_id
+    ).delete()
     db_wrapper.db.query(KGEntityRelationshipDatabase).filter(
         (KGEntityRelationshipDatabase.from_entity_id == entity_id)
         | (KGEntityRelationshipDatabase.to_entity_id == entity_id)
@@ -3233,7 +3611,9 @@ async def kg_delete_entity(
     db_wrapper.db.commit()
 
 
-@router.post("/projects/{projectID}/kg/entities/{entity_id}/merge", tags=["Knowledge Graph"])
+@router.post(
+    "/projects/{projectID}/kg/entities/{entity_id}/merge", tags=["Knowledge Graph"]
+)
 async def kg_merge_entity(
     request: Request,
     projectID: int = PathParam(description="Project ID"),
@@ -3252,7 +3632,10 @@ async def kg_merge_entity(
 
     success = merge_entities(db_wrapper, primary_id=target_id, secondary_id=entity_id)
     if not success:
-        raise HTTPException(status_code=400, detail="Merge failed (entities not found, same id, or different projects)")
+        raise HTTPException(
+            status_code=400,
+            detail="Merge failed (entities not found, same id, or different projects)",
+        )
     return {"merged_into": target_id}
 
 
@@ -3267,7 +3650,12 @@ async def kg_find_duplicates(
 ):
     """List potential duplicate entity pairs based on name similarity."""
     from restai.knowledge_graph import compute_potential_duplicates
-    return {"candidates": compute_potential_duplicates(db_wrapper, projectID, threshold=threshold, limit=limit)}
+
+    return {
+        "candidates": compute_potential_duplicates(
+            db_wrapper, projectID, threshold=threshold, limit=limit
+        )
+    }
 
 
 @router.get("/projects/{projectID}/kg/graph", tags=["Knowledge Graph"])
@@ -3275,14 +3663,21 @@ async def kg_get_graph(
     request: Request,
     projectID: int = PathParam(description="Project ID"),
     type: Optional[str] = Query(None, description="Filter nodes by entity type"),
-    limit: int = Query(100, ge=1, le=500, description="Max number of top entities to include"),
+    limit: int = Query(
+        100, ge=1, le=500, description="Max number of top entities to include"
+    ),
     user: User = Depends(get_current_username_project),
     db_wrapper: DBWrapper = Depends(get_db_wrapper),
 ):
     """Return nodes and edges for knowledge graph visualization."""
-    from restai.models.databasemodels import KGEntityDatabase, KGEntityRelationshipDatabase
+    from restai.models.databasemodels import (
+        KGEntityDatabase,
+        KGEntityRelationshipDatabase,
+    )
 
-    q = db_wrapper.db.query(KGEntityDatabase).filter(KGEntityDatabase.project_id == projectID)
+    q = db_wrapper.db.query(KGEntityDatabase).filter(
+        KGEntityDatabase.project_id == projectID
+    )
     if type:
         q = q.filter(KGEntityDatabase.entity_type == type)
     top_entities = q.order_by(KGEntityDatabase.mention_count.desc()).limit(limit).all()
@@ -3331,7 +3726,9 @@ async def kg_query(
     if project.props.type != "rag":
         raise HTTPException(status_code=400, detail="Only available for RAG projects.")
     if not project.props.options.enable_knowledge_graph:
-        raise HTTPException(status_code=400, detail="Knowledge graph is not enabled for this project.")
+        raise HTTPException(
+            status_code=400, detail="Knowledge graph is not enabled for this project."
+        )
 
     brain = request.app.state.brain
 
@@ -3394,11 +3791,14 @@ async def kg_query(
         }
 
     matched_entity_ids = [e.id for e in matched_entities]
-    matched_sources = list({
-        m.source for m in db_wrapper.db.query(KGEntityMentionDatabase)
-        .filter(KGEntityMentionDatabase.entity_id.in_(matched_entity_ids))
-        .all()
-    })
+    matched_sources = list(
+        {
+            m.source
+            for m in db_wrapper.db.query(KGEntityMentionDatabase)
+            .filter(KGEntityMentionDatabase.entity_id.in_(matched_entity_ids))
+            .all()
+        }
+    )
 
     if not matched_sources:
         return {
@@ -3436,9 +3836,14 @@ async def kg_query(
 
     try:
         from llama_index.core.base.llms.types import ChatMessage, MessageRole
+
         llm_model = brain.get_llm(project.props.llm, db_wrapper)
         resp = llm_model.llm.chat([ChatMessage(role=MessageRole.USER, content=prompt)])
-        answer = resp.message.content.strip() if resp.message and resp.message.content else ""
+        answer = (
+            resp.message.content.strip()
+            if resp.message and resp.message.content
+            else ""
+        )
     except Exception as e:
         logging.exception(e)
         raise HTTPException(status_code=500, detail="LLM call failed")
@@ -3461,7 +3866,11 @@ async def kg_rebuild(
 ):
     """Re-extract entities for ALL sources in this project. Runs in background."""
     check_not_restricted(user)
-    from restai.models.databasemodels import KGEntityDatabase, KGEntityMentionDatabase, KGEntityRelationshipDatabase
+    from restai.models.databasemodels import (
+        KGEntityDatabase,
+        KGEntityMentionDatabase,
+        KGEntityRelationshipDatabase,
+    )
 
     project = get_project(projectID, db_wrapper, request.app.state.brain)
     if project.props.type != "rag":
@@ -3473,13 +3882,16 @@ async def kg_rebuild(
     db_wrapper.db.query(KGEntityMentionDatabase).filter(
         KGEntityMentionDatabase.project_id == projectID
     ).delete()
-    db_wrapper.db.query(KGEntityDatabase).filter(KGEntityDatabase.project_id == projectID).delete()
+    db_wrapper.db.query(KGEntityDatabase).filter(
+        KGEntityDatabase.project_id == projectID
+    ).delete()
     db_wrapper.db.commit()
 
     sources = project.vector.list() if project.vector is not None else []
 
     def _rebuild():
         from restai.knowledge_graph import extract_and_persist
+
         new_db = DBWrapper()
         try:
             for src in sources:
@@ -3487,7 +3899,9 @@ async def kg_rebuild(
                     chunk_data = project.vector.find_source(src)
                     full_text = "\n".join(chunk_data.get("documents") or [])
                     if full_text:
-                        extract_and_persist(projectID, src, full_text, request.app.state.brain, new_db)
+                        extract_and_persist(
+                            projectID, src, full_text, request.app.state.brain, new_db
+                        )
                 except Exception as e:
                     logging.warning("Rebuild failed for source %s: %s", src, e)
         finally:
@@ -3497,7 +3911,10 @@ async def kg_rebuild(
                 pass
 
     background_tasks.add_task(_rebuild)
-    return {"message": f"Rebuild scheduled for {len(sources)} sources", "source_count": len(sources)}
+    return {
+        "message": f"Rebuild scheduled for {len(sources)} sources",
+        "source_count": len(sources),
+    }
 
 
 def _mobile_default_host(request: Request) -> str:
@@ -3515,7 +3932,9 @@ def _mobile_key_description(project_name: str) -> str:
     return f"RESTai Mobile — project {project_name}"
 
 
-def _mobile_status_payload(request: Request, project_db, api_key_row, api_key_plaintext: Optional[str] = None) -> dict:
+def _mobile_status_payload(
+    request: Request, project_db, api_key_row, api_key_plaintext: Optional[str] = None
+) -> dict:
     """Shape GET/POST response; surfaces plaintext key while enabled (for QR)."""
     enabled = api_key_row is not None
     payload = {
@@ -3528,6 +3947,7 @@ def _mobile_status_payload(request: Request, project_db, api_key_row, api_key_pl
         if plaintext is None:
             try:
                 from restai.utils.crypto import decrypt_api_key
+
                 plaintext = decrypt_api_key(api_key_row.encrypted_key)
             except Exception:
                 plaintext = None
@@ -3548,7 +3968,12 @@ def _get_mobile_api_key(db_wrapper: DBWrapper, project_db):
     if not key_id:
         return None
     from restai.models.databasemodels import ApiKeyDatabase
-    row = db_wrapper.db.query(ApiKeyDatabase).filter(ApiKeyDatabase.id == int(key_id)).first()
+
+    row = (
+        db_wrapper.db.query(ApiKeyDatabase)
+        .filter(ApiKeyDatabase.id == int(key_id))
+        .first()
+    )
     return row
 
 
@@ -3622,7 +4047,9 @@ async def mobile_enable(
 
     api_key_row, plaintext = _mint_mobile_api_key(db_wrapper, user, project_db)
     _persist_mobile_key(db_wrapper, project_db, api_key_row.id)
-    return _mobile_status_payload(request, project_db, api_key_row, api_key_plaintext=plaintext)
+    return _mobile_status_payload(
+        request, project_db, api_key_row, api_key_plaintext=plaintext
+    )
 
 
 @router.post("/projects/{projectID}/mobile/disable", tags=["Mobile"])
@@ -3666,4 +4093,6 @@ async def mobile_regenerate(
 
     api_key_row, plaintext = _mint_mobile_api_key(db_wrapper, user, project_db)
     _persist_mobile_key(db_wrapper, project_db, api_key_row.id)
-    return _mobile_status_payload(request, project_db, api_key_row, api_key_plaintext=plaintext)
+    return _mobile_status_payload(
+        request, project_db, api_key_row, api_key_plaintext=plaintext
+    )

--- a/tests/test_chat_resume.py
+++ b/tests/test_chat_resume.py
@@ -1,0 +1,230 @@
+"""Tests for chat_resume.
+
+In-memory backend (the no-Redis "current setup") is exercised in CI by
+patching ``build_redis_url`` to return None. The cross-instance Redis path
+only runs when ``REDIS_TEST_URL`` is set (else it skips) so it can be
+verified against a real Redis without requiring one in CI.
+"""
+
+import asyncio
+import os
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+import restai.chat_resume as cr
+from restai.chat_resume import (
+    RedisSubscriberSession,
+    evict,
+    get_or_create,
+    lookup,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    """Each test runs under its own ``asyncio.run`` loop; recreate the
+    module-level lock so it binds to that loop, and clear shared state."""
+    cr._sessions.clear()
+    cr._sessions_lock = asyncio.Lock()
+    cr._redis_client = None
+    cr._redis_url = None
+    yield
+    cr._sessions.clear()
+    cr._redis_client = None
+    cr._redis_url = None
+
+
+async def _drain(session, last_event_id=0, timeout=2.0):
+    """Collect SSE chunks from a subscribe() async generator. Stops on the
+    producer's done signal (StopAsyncIteration) or after `timeout` idle."""
+    out = []
+    agen = session.subscribe(last_event_id=last_event_id)
+    try:
+        while True:
+            out.append(await asyncio.wait_for(agen.__anext__(), timeout=timeout))
+    except (StopAsyncIteration, asyncio.TimeoutError):
+        pass
+    finally:
+        await agen.aclose()
+    return out
+
+
+# --------------------------------------------------------------------------
+# In-memory backend (no Redis configured)
+# --------------------------------------------------------------------------
+
+
+@patch("restai.chat_resume.config.build_redis_url", return_value=None)
+def test_get_or_create_new_then_in_flight_dedup(_mock):
+    async def scenario():
+        s1, new1 = await get_or_create("k")
+        s2, new2 = await get_or_create("k")
+        return s1, new1, s2, new2
+
+    s1, new1, s2, new2 = asyncio.run(scenario())
+    assert new1 is True, "first caller owns the producer"
+    assert new2 is False, "second caller attaches to the in-flight session"
+    assert s1 is s2
+
+
+@patch("restai.chat_resume.config.build_redis_url", return_value=None)
+def test_subscribe_replays_then_ends_on_done(_mock):
+    async def scenario():
+        s, _ = await get_or_create("k")
+        await s.append("data: one\n\n")
+        await s.append("data: two\n\n")
+        await s.finish()
+        return await _drain(s)
+
+    out = asyncio.run(scenario())
+    joined = "".join(out)
+    assert "data: one" in joined
+    assert "data: two" in joined
+    assert "id: 1" in joined and "id: 2" in joined
+
+
+@patch("restai.chat_resume.config.build_redis_url", return_value=None)
+def test_subscribe_skips_already_seen(_mock):
+    async def scenario():
+        s, _ = await get_or_create("k")
+        await s.append("data: 1\n\n")
+        await s.append("data: 2\n\n")
+        await s.append("data: 3\n\n")
+        await s.finish()
+        return await _drain(s, last_event_id=2)
+
+    joined = "".join(asyncio.run(scenario()))
+    assert "data: 3" in joined and "id: 3" in joined
+    assert "data: 1" not in joined
+    assert "data: 2" not in joined
+
+
+@patch("restai.chat_resume.config.build_redis_url", return_value=None)
+def test_subscribe_live_tail(_mock):
+    async def scenario():
+        s, _ = await get_or_create("live")
+        received = []
+
+        async def consumer():
+            async for chunk in s.subscribe(0):
+                received.append(chunk)
+
+        task = asyncio.create_task(consumer())
+        await asyncio.sleep(0.05)
+        await s.append("data: a\n\n")
+        await s.append("data: b\n\n")
+        await asyncio.sleep(0.05)
+        await s.finish()
+        await asyncio.wait_for(task, timeout=2)
+        return received
+
+    received = asyncio.run(scenario())
+    joined = "".join(received)
+    assert "data: a" in joined
+    assert "data: b" in joined
+
+
+@patch("restai.chat_resume.config.build_redis_url", return_value=None)
+def test_cancel_emits_stopped_marker_and_ends(_mock):
+    async def scenario():
+        s, _ = await get_or_create("c")
+        await s.append("data: partial\n\n")
+        await s.cancel()
+        assert s.done is True
+        return await _drain(s)
+
+    joined = "".join(asyncio.run(scenario()))
+    assert "partial" in joined
+    assert "stopped" in joined
+    assert "event: close" in joined
+
+
+@patch("restai.chat_resume.config.build_redis_url", return_value=None)
+def test_finished_session_starts_fresh_run(_mock):
+    """A reused chat_id whose prior turn finished must NOT be reattached —
+    get_or_create discards it and returns a brand new producer session."""
+
+    async def scenario():
+        s1, new1 = await get_or_create("k")
+        await s1.finish()
+        s2, new2 = await get_or_create("k")
+        return s1, new1, s2, new2
+
+    s1, new1, s2, new2 = asyncio.run(scenario())
+    assert new1 is True
+    assert new2 is True, "finished session should not be reattached"
+    assert s1 is not s2
+
+
+@patch("restai.chat_resume.config.build_redis_url", return_value=None)
+def test_is_in_flight_transitions(_mock):
+    async def scenario():
+        s, _ = await get_or_create("k")
+        before = await s.is_in_flight()
+        await s.finish()
+        after = await s.is_in_flight()
+        return before, after
+
+    before, after = asyncio.run(scenario())
+    assert before is True
+    assert after is False
+
+
+@patch("restai.chat_resume.config.build_redis_url", return_value=None)
+def test_lookup_and_evict(_mock):
+    async def scenario():
+        await get_or_create("k")
+        found = await lookup("k")
+        removed = await evict("k")
+        after = await lookup("k")
+        unknown = await lookup("nope")
+        return found, removed, after, unknown
+
+    found, removed, after, unknown = asyncio.run(scenario())
+    assert found is not None
+    assert removed is True
+    assert after is None
+    assert unknown is None
+
+
+# --------------------------------------------------------------------------
+# Cross-instance Redis backend (opt-in via REDIS_TEST_URL)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not os.environ.get("REDIS_TEST_URL"), reason="REDIS_TEST_URL not set"
+)
+def test_redis_cross_instance_replay_and_evict():
+    url = os.environ["REDIS_TEST_URL"]
+    cid = "chat-resume-test-" + uuid.uuid4().hex
+
+    with patch("restai.chat_resume.config.build_redis_url", return_value=url):
+
+        async def scenario():
+            # Producing instance: claims the lock, mirrors to Redis.
+            sess, is_new = await get_or_create(cid)
+            assert is_new is True
+            assert getattr(sess, "_redis", False) is True
+            await sess.append('data: {"text": "hello"}\n\n')
+            await sess.finish()
+
+            # Another instance only sees Redis — a subscriber proxy.
+            proxy = RedisSubscriberSession(chat_id=cid)
+            assert await proxy.is_in_flight() is False
+            out = await _drain(proxy)
+            joined = "".join(out)
+            assert "hello" in joined
+
+            # lookup from "another instance" (no local session) finds it.
+            cr._sessions.clear()
+            found = await lookup(cid)
+            assert isinstance(found, RedisSubscriberSession)
+
+            # evict clears the shared keys.
+            assert await evict(cid) is True
+            assert await lookup(cid) is None
+
+        asyncio.run(scenario())


### PR DESCRIPTION
## Summary

This PR applies Black code formatting to three core modules (`restai/routers/projects.py`, `restai/chat_resume.py`, `restai/helper.py`) to improve code consistency and readability. Additionally, it adds comprehensive test coverage for the chat resume functionality and enhances the Redis-backed stream resume system with multi-instance support.

## Key Changes

### Code Formatting (Black)
- **`restai/routers/projects.py`**: Reformatted long lines, multi-line imports, function parameters, and dictionary/list literals to comply with Black's 88-character line limit
- **`restai/chat_resume.py`**: Reformatted docstrings, function signatures, and complex expressions
- **`restai/helper.py`**: Reformatted imports, function calls, and error messages

### Chat Resume Enhancements
- **Redis multi-instance support**: Added Redis Stream mirroring so reconnects/cancels can land on any instance behind a load balancer
  - Producer instance mirrors events to Redis Stream (`XADD`) and holds a producer-claim lock
  - Non-producer instances can `lookup`/`subscribe` via Redis, replaying + tailing the buffer
  - Cross-instance cancel via Redis pub/sub control channel
  - Graceful degradation: Redis errors fall back to in-memory (same-instance stream still works)

- **New `RedisSubscriberSession` class**: Handles subscribing to remote producer streams when the local session doesn't own the producer task
  - Replays buffered events from Redis Stream
  - Tails live events via `XREAD` blocking
  - Respects `Last-Event-ID` for resumption

- **Producer-side enhancements**:
  - `start_cancel_watcher()` spawns a pub/sub listener for remote cancellation
  - `_mirror_append()`, `_mirror_end()`, `_publish_cancel()` handle Redis synchronization
  - Lock token guards against deleting locks claimed by later producers

- **Updated module docstring**: Clarifies single-instance (in-memory) vs. multi-instance (Redis) behavior

### Test Coverage
- **`tests/test_chat_resume.py`** (new): 230 lines of comprehensive tests
  - In-memory backend tests (no Redis): deduplication, replay, live tailing, cancellation, session lifecycle
  - Fixtures for state reset between tests
  - Helper `_drain()` utility for collecting SSE chunks
  - Skippable Redis tests (run when `REDIS_TEST_URL` is set)

## Implementation Details

- **Lua script for atomic lock release**: `_UNLOCK_LUA` ensures only the lock owner can delete it, preventing race conditions when multiple producers claim the same `chat_id`
- **Lazy Redis client**: `_redis()` function rebuilds the client when the configured URL changes, allowing admin Settings edits to take effect without restart
- **Graceful error handling**: Redis failures log warnings but don't crash; in-memory buffer continues working for same-instance subscribers
- **Event ID consistency**: Plain integers assigned by producer, stored as Redis Stream field `s`, so `Last-Event-ID` works across instances
- **TTL management**: Active sessions use `ACTIVE_TTL` (3600s); finished sessions drop to `GRACE_SECONDS` for self-expiration

https://claude.ai/code/session_01MKHLsgWnxZHZB7tkFwoPgh