### PR TITLE
fix(auth): add SSRF protection to MCP server HTTP/HTTPS/SSE hosts

### DIFF
--- a/restai/auth.py
+++ b/restai/auth.py
@@ -1,6 +1,7 @@
 import base64
 import json
 from datetime import datetime, timedelta, timezone
+from urllib.parse import urlparse as _urlparse
 from typing import Optional
 from fastapi import Depends, HTTPException, Request
 import jwt
@@ -244,8 +245,24 @@ def check_user_can_use_mcp_host(user: User, host: str) -> None:
     """Refuse stdio MCP transport for non-admins. Network transports
     pass through (the MCP server runs elsewhere, no local subprocess
     is created).
+
+    Also validates that HTTP/HTTPS/SSE hosts do not resolve to private or
+    internal IP addresses (SSRF protection). Uses the same _BLOCKED_NETWORKS
+    blocklist as URL ingestion and image resolution.
     """
     if _mcp_host_is_network(host):
+        from restai.helper import _is_private_ip
+        try:
+            hostname = _urlparse(host).hostname
+        except Exception:
+            raise HTTPException(status_code=400, detail="Invalid MCP server URL")
+        if not hostname:
+            raise HTTPException(status_code=400, detail="MCP server URL has no valid hostname")
+        if _is_private_ip(hostname):
+            raise HTTPException(
+                status_code=400,
+                detail="MCP server URL resolves to a private/internal address; SSRF blocked",
+            )
         return
     if user.is_admin:
         return


### PR DESCRIPTION
## Problem

`check_user_can_use_mcp_host()` in `restai/auth.py` returns immediately for any URL beginning with `http://`, `https://`, or `sse://` without validating the destination host. An authenticated project member can configure an MCP server pointing at the cloud instance metadata service (`169.254.169.254`) or internal RFC-1918 services.

Attack path:
1. PATCH project options: `{"mcp_servers": [{"host": "http://169.254.169.254/latest/meta-data/iam/security-credentials/", "headers": {}}]}`
2. `check_user_can_use_mcp_host` is called — since the URL starts with `http://` it returns without SSRF check
3. Call `GET /projects/{id}/tools` → `BasicMCPClient(mcp_server.host)` makes an outbound request to cloud IMDS
4. Error/response content is returned to the caller

The existing `_is_private_ip()` SSRF blocklist in `helper.py` is **never called** on the MCP host path.

**CVSS 3.1:** AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N = 7.7 HIGH — CWE-918

## Fix

Extends `check_user_can_use_mcp_host()` to call `_is_private_ip()` on the parsed hostname for all HTTP/HTTPS/SSE MCP hosts, reusing the same SSRF blocklist that URL ingestion and image resolution already use.

```diff
diff --git a/restai/auth.py b/restai/auth.py
index 7ce361e..ac59e5a 100644
--- a/restai/auth.py
+++ b/restai/auth.py
@@ -1,6 +1,7 @@
 import base64
 import json
 from datetime import datetime, timedelta, timezone
+from urllib.parse import urlparse as _urlparse
 from typing import Optional
 from fastapi import Depends, HTTPException, Request
 import jwt
@@ -244,8 +245,24 @@ def check_user_can_use_mcp_host(user: User, host: str) -> None:
     """Refuse stdio MCP transport for non-admins. Network transports
     pass through (the MCP server runs elsewhere, no local subprocess
     is created).
+
+    Also validates that HTTP/HTTPS/SSE hosts do not resolve to private or
+    internal IP addresses (SSRF protection). Uses the same _BLOCKED_NETWORKS
+    blocklist as URL ingestion and image resolution.
     """
     if _mcp_host_is_network(host):
+        from restai.helper import _is_private_ip
+        try:
+            hostname = _urlparse(host).hostname
+        except Exception:
+            raise HTTPException(status_code=400, detail="Invalid MCP server URL")
+        if not hostname:
+            raise HTTPException(status_code=400, detail="MCP server URL has no valid hostname")
+        if _is_private_ip(hostname):
+            raise HTTPException(
+                status_code=400,
+                detail="MCP server URL resolves to a private/internal address; SSRF blocked",
+            )
         return
     if user.is_admin:
         return
```

## Test Plan
- [ ] Existing test suite passes (`pytest tests/`)
- [ ] PATCH project with `mcp_servers: [{host: "http://169.254.169.254/"}]` → HTTP 400 "SSRF blocked"
- [ ] PATCH project with `mcp_servers: [{host: "http://10.0.0.1:6333/"}]` → HTTP 400
- [ ] PATCH project with `mcp_servers: [{host: "https://mcp.example.com/"}]` → accepted normally
- [ ] stdio MCP transport still correctly blocked for non-admins

## Security Note

Severity: HIGH (CVSS 3.1: AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N = 7.7). CWE-918.
Any authenticated project member on cloud-deployed RESTai instances can reach the cloud instance metadata service and exfiltrate IAM credentials. GitHub private vulnerability reporting is enabled on this repo — if you prefer coordinated disclosure, please close this PR and open a private advisory.