### PR TITLE
fix(ssrf): block IPv4-mapped IPv6 addresses in _is_private_ip

### DIFF
--- a/restai/helper.py
+++ b/restai/helper.py
@@ -42,6 +42,10 @@ _BLOCKED_NETWORKS = [
     ipaddress.ip_network("169.254.0.0/16"),
     ipaddress.ip_network("::1/128"),
     ipaddress.ip_network("fc00::/7"),
+    # IPv4-mapped IPv6 space -- covers ::ffff:10.x, ::ffff:192.168.x, ::ffff:169.254.x etc.
+    # Without this, ip_address('::ffff:169.254.169.254') is an IPv6Address not contained in
+    # '169.254.0.0/16' (an IPv4Network), bypassing the blocklist on dual-stack Linux hosts.
+    ipaddress.ip_network("::ffff:0:0/96"),
 ]
 
 _URL_PATTERN = re.compile(
@@ -60,6 +64,14 @@ def _is_private_ip(hostname: str) -> bool:
         for network in _BLOCKED_NETWORKS:
             if ip in network:
                 return True
+    # Secondary check: unwrap IPv4-mapped IPv6 addresses and recheck against IPv4 blocklists.
+    # Handles the case where getaddrinfo returns ::ffff:<private-ip> on dual-stack systems.
+    for addrinfo in addrinfos:
+        ip = ipaddress.ip_address(addrinfo[4][0])
+        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+            for network in _BLOCKED_NETWORKS:
+                if ip.ipv4_mapped in network:
+                    return True
     return False
 
 


### PR DESCRIPTION
## Problem

`_BLOCKED_NETWORKS` in `restai/helper.py` includes `169.254.0.0/16` (an `IPv4Network`) but not `::ffff:0:0/96` (IPv4-mapped IPv6 space). Python's `ipaddress.ip_address('::ffff:169.254.169.254')` returns an `IPv6Address` object that is not contained in any listed `IPv4Network`, so `_is_private_ip()` returns `False` and the SSRF check passes on dual-stack Linux hosts.

An authenticated user can supply `http://[::ffff:169.254.169.254]/latest/meta-data/` to:
- `POST /projects/{id}/ingest-url` → Selenium fetches the URL server-side; content stored in RAG knowledge base
- Image URL fields in chat → `resolve_image()` → `_safe_get()` makes a `requests.get` to the URL

**CVSS 3.1:** AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:N/A:N = 7.0 HIGH — CWE-918

## Fix

Two-part change to `_BLOCKED_NETWORKS` and `_is_private_ip()`:
1. Add `::ffff:0:0/96` to `_BLOCKED_NETWORKS`
2. Secondary loop that unwraps `ipv4_mapped` addresses and rechecks against IPv4 blocklist entries (defense-in-depth)

```diff
diff --git a/restai/helper.py b/restai/helper.py
index e6d84f4..5c97ff2 100644
--- a/restai/helper.py
+++ b/restai/helper.py
@@ -42,6 +42,10 @@ _BLOCKED_NETWORKS = [
     ipaddress.ip_network("169.254.0.0/16"),
     ipaddress.ip_network("::1/128"),
     ipaddress.ip_network("fc00::/7"),
+    # IPv4-mapped IPv6 space -- covers ::ffff:10.x, ::ffff:192.168.x, ::ffff:169.254.x etc.
+    # Without this, ip_address('::ffff:169.254.169.254') is an IPv6Address not contained in
+    # '169.254.0.0/16' (an IPv4Network), bypassing the blocklist on dual-stack Linux hosts.
+    ipaddress.ip_network("::ffff:0:0/96"),
 ]
 
 _URL_PATTERN = re.compile(
@@ -60,6 +64,14 @@ def _is_private_ip(hostname: str) -> bool:
         for network in _BLOCKED_NETWORKS:
             if ip in network:
                 return True
+    # Secondary check: unwrap IPv4-mapped IPv6 addresses and recheck against IPv4 blocklists.
+    # Handles the case where getaddrinfo returns ::ffff:<private-ip> on dual-stack systems.
+    for addrinfo in addrinfos:
+        ip = ipaddress.ip_address(addrinfo[4][0])
+        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+            for network in _BLOCKED_NETWORKS:
+                if ip.ipv4_mapped in network:
+                    return True
     return False
 
 
```

## Test Plan
- [ ] Existing test suite passes (`pytest tests/`)
- [ ] `_is_private_ip('[::ffff:169.254.169.254]')` → `True` (was `False`)
- [ ] `_is_private_ip('[::ffff:127.0.0.1]')` → `True` (was `False`)
- [ ] `_is_private_ip('example.com')` → `False` (no regression)
- [ ] `POST /projects/{id}/ingest-url` with `url: 'http://[::ffff:169.254.169.254]/'` → HTTP 400

## Security Note

Severity: HIGH (CVSS 3.1: AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:N/A:N = 7.0). CWE-918. Affects dual-stack cloud deployments. Companion to #177 (MCP SSRF).