### PR TITLE
Speed up test suite 4x; add ruff, backend+frontend test coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,11 +26,14 @@ jobs:
       - name: Install dependencies
         run: uv sync --no-group gpu
 
+      - name: Lint
+        run: uv run --no-group gpu ruff check .
+
       - name: Initialize database
         run: uv run --no-group gpu python database.py
 
       - name: Run tests
-        run: uv run --no-group gpu pytest tests/ -v --tb=short --ignore=tests/test_projects.py
+        run: uv run --no-group gpu pytest tests/ -v --tb=short --ignore=tests/test_projects.py --cov --cov-report=term
 
       - uses: actions/setup-node@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+.ruff_cache/
 cover/
 
 # Translations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,12 +26,15 @@ make frontend         # npm install + npm run build
 cd frontend && npm start  # Dev server (port 3000, proxies to 9000)
 
 # Tests
-pytest tests
+make test             # uv run pytest tests
 pytest tests/test_projects.py -v
 pytest tests/test_projects.py::test_create_project
+make coverage         # pytest with coverage (term-missing + htmlcov/)
 
 # Code quality
-make code             # black app/*.py
+make lint             # ruff check . (zero-violation baseline — CI enforces it)
+make code             # ruff check . --fix
+make format           # ruff format . (opt-in; not yet applied repo-wide)
 
 # WordPress plugin
 cd wordpress && zip -r restai.zip restai
@@ -440,6 +443,10 @@ Integer Query/Form params have `ge`/`le` bounds. File uploads sanitized via `san
 - `tests/test_comments.py` — project comments
 
 `tests/test_projects.py` may fail if no LLMs configured (pre-existing).
+
+**Linting**: ruff, configured in `pyproject.toml` (`[tool.ruff]`). Default E/F rules with pragmatic ignores (`E402` late imports, `E712` SQLAlchemy `== True`, `E731`, `E741`); `migrations/` and `examples/` excluded. The repo is at zero violations and CI runs `ruff check .` before tests — keep it clean. Some `__init__.py` re-exports carry `# noqa: F401` because tests/monkeypatching reach them via the package namespace; module-level "unused" imports may be compat re-exports (e.g. `restai.database.verify_password`) — check importers before deleting.
+
+**Coverage**: pytest-cov (`[tool.coverage.run]` sources: `restai`, `crons`, `modules`). `make coverage` for local HTML report; CI prints the term report.
 
 ## Key env vars
 

--- a/Makefile
+++ b/Makefile
@@ -181,11 +181,24 @@ version:
 
 .PHONY: test
 test:
-	pytest tests
+	uv run --no-group gpu pytest tests
+
+.PHONY: coverage
+coverage:
+	uv run --no-group gpu pytest tests --ignore=tests/test_projects.py --cov --cov-report=term-missing:skip-covered --cov-report=html
+	@echo "HTML report: htmlcov/index.html"
+
+.PHONY: lint
+lint:
+	uv run --no-group gpu ruff check .
 
 .PHONY: code
 code:
-	black app/*.py
+	uv run --no-group gpu ruff check . --fix
+
+.PHONY: format
+format:
+	uv run --no-group gpu ruff format .
 
 .PHONY: clean
 clean:

--- a/crons/browser_cleanup.py
+++ b/crons/browser_cleanup.py
@@ -62,7 +62,7 @@ def main():
         # tool call. Reading from here gives true idle time across all
         # RESTai instances. Orphans (created before this table existed,
         # or by some other RESTai version) fall back to container age.
-        from datetime import datetime, timezone
+        from datetime import timezone
         from restai.models.databasemodels import BrowserChatActivityDatabase
 
         db = open_db_wrapper()

--- a/crons/bulk_ingest.py
+++ b/crons/bulk_ingest.py
@@ -18,7 +18,7 @@ logger = logging.getLogger("restai.bulk_ingest")
 def main():
     from restai.settings import ensure_settings_table
     from restai.database import engine as db_engine, open_db_wrapper
-    from restai.models.databasemodels import BulkIngestJobDatabase, ProjectDatabase
+    from restai.models.databasemodels import BulkIngestJobDatabase
     from restai.brain import Brain
     from restai.observability.cron_log import CronLogger
 

--- a/crons/routines.py
+++ b/crons/routines.py
@@ -15,7 +15,6 @@ from datetime import datetime, timezone
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
 logger = logging.getLogger("restai.routines")
 
-from restai import config
 from restai.settings import ensure_settings_table
 from restai.database import open_db_wrapper, engine as db_engine
 from restai.brain import Brain

--- a/crons/slack.py
+++ b/crons/slack.py
@@ -12,12 +12,10 @@ import asyncio
 import inspect
 import json
 import logging
-import time
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
 logger = logging.getLogger("restai.slack")
 
-from restai import config
 from restai.settings import ensure_settings_table
 from restai.database import open_db_wrapper, engine as db_engine
 from restai.models.databasemodels import ProjectDatabase

--- a/crons/sync.py
+++ b/crons/sync.py
@@ -9,13 +9,11 @@ Usage:
 
 import json
 import logging
-import sys
 from datetime import datetime, timezone
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
 logger = logging.getLogger("restai.integrations.sync")
 
-from restai import config
 from restai.settings import ensure_settings_table
 from restai.database import open_db_wrapper, engine as db_engine
 from restai.models.databasemodels import ProjectDatabase

--- a/crons/telegram.py
+++ b/crons/telegram.py
@@ -15,7 +15,6 @@ import logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
 logger = logging.getLogger("restai.comms.telegram")
 
-from restai import config
 from restai.settings import ensure_settings_table
 from restai.database import open_db_wrapper, engine as db_engine
 from restai.models.databasemodels import ProjectDatabase

--- a/database.py
+++ b/database.py
@@ -14,10 +14,7 @@ from restai.config import (
     SQLITE_PATH,
 )
 from restai.models.databasemodels import (
-    ApiKeyDatabase,
     Base,
-    ProjectDatabase,
-    SettingDatabase,
     UserDatabase,
     TeamDatabase
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,11 +120,42 @@ gpu = [
     "triton>=3.2.0,<4"
 ]
 dev = [
-    "pylint>=3.3.0,<4",
     "debugpy>=1.8.20,<2",
-    "black>=25.12.0,<27",
     "fakeredis>=2.35.1,<3",
+    "ruff>=0.15.0,<0.16",
+    "pytest>=8.3.0,<9",
+    "pytest-cov>=6.0.0,<8",
 ]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 120
+# Migrations are frozen history — don't churn them. Examples are demo code.
+extend-exclude = ["migrations", "examples"]
+
+[tool.ruff.lint]
+# Ruff's default ruleset (E4/E7/E9 + F) minus rules that fight
+# deliberate patterns in this codebase:
+ignore = [
+    "E402", # late imports are load-bearing (config bootstrap, lifespan, conftest env setup)
+    "E712", # `== True` is SQLAlchemy filter syntax here, not a boolean comparison
+    "E731", # lambda assignments are used for small callbacks
+    "E741", # single-letter loop vars are established style in query code
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.coverage.run]
+source = ["restai", "crons", "modules"]
+omit = [
+    # GPU-only worker entrypoints — never imported in CPU test runs
+    "restai/image/workers/*",
+    "restai/audio/workers/*",
+]
+
+[tool.coverage.report]
+precision = 1
 
 [tool.uv]
 default-groups = [

--- a/restai/agent2/__init__.py
+++ b/restai/agent2/__init__.py
@@ -5,9 +5,9 @@ Pure-Python ReAct-style agent loop built on top of raw provider SDKs
 wired to RESTai's existing tool registry, LLM database rows, guards, and
 streaming protocol.
 """
-from .agent import Agent2Error, Agent2Runtime, Agent2UnsupportedLLMError
+from .agent import Agent2Error, Agent2Runtime
 from .mcp_client import MCPSessionPool
-from .providers import ProviderConfig, build_provider_for_llm
+from .providers import Agent2UnsupportedLLMError, ProviderConfig, build_provider_for_llm
 from .tool_adapter import AdaptedTool, adapt_function_tools
 from .types import (
     AgentEvent,

--- a/restai/agent2/agent.py
+++ b/restai/agent2/agent.py
@@ -10,8 +10,6 @@ from uuid import uuid4
 
 from .compression import compress_session, truncate_text_to_token_budget
 from .providers import (
-    Agent2ProviderError,
-    Agent2UnsupportedLLMError,
     Provider,
     ProviderConfig,
 )

--- a/restai/agent2/react_prompt.py
+++ b/restai/agent2/react_prompt.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass, field
-from typing import Any, Literal, Optional, Sequence
+from typing import Literal, Optional, Sequence
 
 from .tool_adapter import AdaptedTool
 

--- a/restai/audio/providers/openai.py
+++ b/restai/audio/providers/openai.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import io
-import os
 
 from openai import OpenAI
 

--- a/restai/audio/runner.py
+++ b/restai/audio/runner.py
@@ -1,4 +1,3 @@
-from torch.multiprocessing import Process
 from ilock import ILock
 from fastapi import UploadFile
 import tempfile
@@ -98,9 +97,9 @@ def generate(
         if temp_file:
             try:
                 os.unlink(temp_file.name)
-            except:
+            except Exception:
                 pass
         try:
             os.unlink(sharedmem_file.name)
-        except:
+        except Exception:
             pass

--- a/restai/audio/workers/crisperwhisper_beta.py
+++ b/restai/audio/workers/crisperwhisper_beta.py
@@ -35,7 +35,6 @@ def worker(prompt, sharedmem):
     from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor, pipeline
         
     file_path = sharedmem["file_path"]
-    filename = sharedmem["filename"]
     
     device = "cuda:0" if torch.cuda.is_available() else "cpu"
     torch_dtype = torch.float16 if torch.cuda.is_available() else torch.float32

--- a/restai/audio/workers/whisper3_large.py
+++ b/restai/audio/workers/whisper3_large.py
@@ -13,7 +13,6 @@ def worker(prompt, sharedmem):
     import restai.config as _cfg
 
     file_path = sharedmem["file_path"]
-    filename = sharedmem["filename"]
 
     device = _cfg.RESTAI_DEFAULT_DEVICE
     torch_dtype = torch.float16 if torch.cuda.is_available() else torch.float32

--- a/restai/audio/workers/whisper3_large_turbo.py
+++ b/restai/audio/workers/whisper3_large_turbo.py
@@ -13,7 +13,6 @@ def worker(prompt, sharedmem):
     import restai.config as _cfg
 
     file_path = sharedmem["file_path"]
-    filename = sharedmem["filename"]
 
     device = _cfg.RESTAI_DEFAULT_DEVICE
     torch_dtype = torch.float16 if torch.cuda.is_available() else torch.float32

--- a/restai/audio/workers/whisper3_lib.py
+++ b/restai/audio/workers/whisper3_lib.py
@@ -16,7 +16,6 @@ def worker(prompt, sharedmem):
     model = whisper.load_model("large-v3")
 
     file_path = sharedmem["file_path"]
-    filename = sharedmem["filename"]
 
     options = sharedmem.get("options", {})
     result = model.transcribe(

--- a/restai/audio/workers/whisperx.py
+++ b/restai/audio/workers/whisperx.py
@@ -33,7 +33,6 @@ def worker(prompt, sharedmem):
     from restai import config
 
     file_path = sharedmem["file_path"]
-    filename = sharedmem["filename"]
 
     device = config.RESTAI_DEFAULT_DEVICE
 

--- a/restai/auth.py
+++ b/restai/auth.py
@@ -10,7 +10,6 @@ from restai.constants import ERROR_MESSAGES
 from restai.database import get_db_wrapper, verify_password, DBWrapper
 from restai.models.databasemodels import ProjectDatabase
 from restai.models.models import User
-import logging
 
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):

--- a/restai/browser/micro_server.py
+++ b/restai/browser/micro_server.py
@@ -6,9 +6,7 @@ import json
 import logging
 import os
 import re
-import sys
 import threading
-import time
 # Single-threaded HTTPServer on purpose: Playwright's sync_api requires
 # that every call comes from the thread that started `sync_playwright()`.
 # ThreadingHTTPServer would spawn a new thread per request and break that

--- a/restai/chat_resume/__init__.py
+++ b/restai/chat_resume/__init__.py
@@ -40,19 +40,21 @@ untouched), then Redis when a URL is configured.
 from __future__ import annotations
 
 from .memory import StreamSession, _sessions, _sessions_lock, gc_expired_locked
+# Several names below are re-exported solely so tests (and runtime callers)
+# can reach/monkeypatch them via the package namespace — hence the noqa.
 from .redis_client import (
-    CONTROL_CHANNEL as _CONTROL_CHANNEL,
-    _local_producer_tasks,
-    control_listener_loop as _control_listener_loop,
+    CONTROL_CHANNEL as _CONTROL_CHANNEL,  # noqa: F401
+    _local_producer_tasks,  # noqa: F401
+    control_listener_loop as _control_listener_loop,  # noqa: F401
     ensure_control_listener as _ensure_control_listener,
     get_redis as _get_redis,
-    handle_control_message as _handle_control_message,
+    handle_control_message as _handle_control_message,  # noqa: F401
 )
 from .redis_session import RedisStreamSession
 from .sse import (
     ACTIVE_TTL_SECONDS,
-    GRACE_SECONDS,
-    MAX_EVENTS_PER_SESSION,
+    GRACE_SECONDS,  # noqa: F401
+    MAX_EVENTS_PER_SESSION,  # noqa: F401
     StreamSessionProtocol,
 )
 

--- a/restai/cli.py
+++ b/restai/cli.py
@@ -93,7 +93,6 @@ def cmd_migrate(args):
 def cmd_init(args):
     _load_env(args.env_file)
 
-    import importlib
     import database  # noqa: F401 — side-effect import that creates tables
     print("Database initialized.")
 

--- a/restai/database.py
+++ b/restai/database.py
@@ -1,44 +1,7 @@
-import logging
-from sqlalchemy import create_engine, func, or_
+from sqlalchemy import create_engine
 from restai import config
-from datetime import datetime, timezone
-from restai.models.databasemodels import (
-    ApiKeyDatabase,
-    LLMDatabase,
-    EmbeddingDatabase,
-    OutputDatabase,
-    ProjectDatabase,
-    ProjectToolDatabase,
-    ProjectRoutineDatabase,
-    CronLogDatabase,
-    SettingDatabase,
-    UserDatabase,
-    TeamDatabase,
-    TeamImageGeneratorDatabase,
-    TeamAudioGeneratorDatabase,
-    WidgetDatabase,
-    ImageGeneratorDatabase,
-    SpeechToTextDatabase,
-    ProjectSecretDatabase,
-)
-from restai.models.models import (
-    LLMModel,
-    LLMUpdate,
-    ProjectModelUpdate,
-    User,
-    UserUpdate,
-    EmbeddingModel,
-    EmbeddingUpdate,
-    TeamModel,
-    TeamModelUpdate,
-    TeamModelCreate,
-)
 from sqlalchemy.orm import sessionmaker, Session
-import bcrypt
-from typing import Optional, List
 from restai.config import MYSQL_HOST, MYSQL_URL, POSTGRES_HOST, POSTGRES_URL
-import json
-from restai.utils.crypto import decrypt_api_key, hash_api_key, verify_api_key_hash
 
 import logging as _logging
 _db_logger = _logging.getLogger(__name__)
@@ -89,7 +52,7 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 # hash_password / verify_password moved to restai.db.passwords; re-exported
 # here so existing `from restai.database import verify_password` keeps working.
-from restai.db.passwords import hash_password, verify_password
+from restai.db.passwords import hash_password, verify_password  # noqa: F401
 
 from restai.db.users import UserMixin
 from restai.db.llms_embeddings import LLMEmbeddingMixin
@@ -101,7 +64,6 @@ from restai.db.project_tools_routines import ProjectToolRoutineMixin
 from restai.db.settings import SettingMixin
 from restai.db.runtime_activity import RuntimeActivityMixin
 from restai.db.payments import PaymentMixin
-from sqlalchemy.orm import Session
 
 
 class DBWrapper(

--- a/restai/db/llms_embeddings.py
+++ b/restai/db/llms_embeddings.py
@@ -5,24 +5,21 @@ Split out of the former monolithic restai/database.py. Each method still uses
 composes these mixins, so the public API is unchanged.
 """
 
+import logging
 import json
 from datetime import datetime, timezone
 from typing import Optional, List
 
-from sqlalchemy import func, or_
 
 from restai.models.databasemodels import (
-    ApiKeyDatabase, LLMDatabase, EmbeddingDatabase, OutputDatabase, ProjectDatabase,
-    ProjectToolDatabase, ProjectRoutineDatabase, CronLogDatabase, SettingDatabase,
-    UserDatabase, TeamDatabase, TeamImageGeneratorDatabase, TeamAudioGeneratorDatabase,
-    WidgetDatabase, ImageGeneratorDatabase, SpeechToTextDatabase, ProjectSecretDatabase,
+    LLMDatabase, EmbeddingDatabase, ProjectDatabase,
+    TeamImageGeneratorDatabase, TeamAudioGeneratorDatabase,
+    ImageGeneratorDatabase, SpeechToTextDatabase,
 )
 from restai.models.models import (
-    LLMModel, LLMUpdate, ProjectModelUpdate, User, UserUpdate, EmbeddingModel,
-    EmbeddingUpdate, TeamModel, TeamModelUpdate, TeamModelCreate,
+    LLMModel, LLMUpdate, EmbeddingModel,
+    EmbeddingUpdate,
 )
-from restai.utils.crypto import decrypt_api_key, hash_api_key, verify_api_key_hash
-from restai.db.passwords import hash_password, verify_password
 
 
 class LLMEmbeddingMixin:

--- a/restai/db/project_secrets.py
+++ b/restai/db/project_secrets.py
@@ -5,24 +5,13 @@ Split out of the former monolithic restai/database.py. Each method still uses
 composes these mixins, so the public API is unchanged.
 """
 
-import json
 from datetime import datetime, timezone
-from typing import Optional, List
+from typing import Optional
 
-from sqlalchemy import func, or_
 
 from restai.models.databasemodels import (
-    ApiKeyDatabase, LLMDatabase, EmbeddingDatabase, OutputDatabase, ProjectDatabase,
-    ProjectToolDatabase, ProjectRoutineDatabase, CronLogDatabase, SettingDatabase,
-    UserDatabase, TeamDatabase, TeamImageGeneratorDatabase, TeamAudioGeneratorDatabase,
-    WidgetDatabase, ImageGeneratorDatabase, SpeechToTextDatabase, ProjectSecretDatabase,
+    ProjectSecretDatabase,
 )
-from restai.models.models import (
-    LLMModel, LLMUpdate, ProjectModelUpdate, User, UserUpdate, EmbeddingModel,
-    EmbeddingUpdate, TeamModel, TeamModelUpdate, TeamModelCreate,
-)
-from restai.utils.crypto import decrypt_api_key, hash_api_key, verify_api_key_hash
-from restai.db.passwords import hash_password, verify_password
 
 
 class ProjectSecretMixin:

--- a/restai/db/project_tools_routines.py
+++ b/restai/db/project_tools_routines.py
@@ -5,24 +5,13 @@ Split out of the former monolithic restai/database.py. Each method still uses
 composes these mixins, so the public API is unchanged.
 """
 
-import json
 from datetime import datetime, timezone
-from typing import Optional, List
+from typing import Optional
 
-from sqlalchemy import func, or_
 
 from restai.models.databasemodels import (
-    ApiKeyDatabase, LLMDatabase, EmbeddingDatabase, OutputDatabase, ProjectDatabase,
-    ProjectToolDatabase, ProjectRoutineDatabase, CronLogDatabase, SettingDatabase,
-    UserDatabase, TeamDatabase, TeamImageGeneratorDatabase, TeamAudioGeneratorDatabase,
-    WidgetDatabase, ImageGeneratorDatabase, SpeechToTextDatabase, ProjectSecretDatabase,
+    ProjectToolDatabase, ProjectRoutineDatabase,
 )
-from restai.models.models import (
-    LLMModel, LLMUpdate, ProjectModelUpdate, User, UserUpdate, EmbeddingModel,
-    EmbeddingUpdate, TeamModel, TeamModelUpdate, TeamModelCreate,
-)
-from restai.utils.crypto import decrypt_api_key, hash_api_key, verify_api_key_hash
-from restai.db.passwords import hash_password, verify_password
 
 
 class ProjectToolRoutineMixin:
@@ -44,7 +33,6 @@ class ProjectToolRoutineMixin:
         )
 
     def upsert_project_tool(self, project_id: int, name: str, description: str, parameters: str, code: str) -> ProjectToolDatabase:
-        from datetime import datetime, timezone
         now = datetime.now(timezone.utc)
         existing = self.get_project_tool_by_name(project_id, name)
         if existing:
@@ -94,7 +82,6 @@ class ProjectToolRoutineMixin:
         return self.db.query(ProjectRoutineDatabase).filter(ProjectRoutineDatabase.id == routine_id).first()
 
     def create_project_routine(self, project_id: int, name: str, message: str, schedule_minutes: int, enabled: bool = True) -> ProjectRoutineDatabase:
-        from datetime import datetime, timezone
         now = datetime.now(timezone.utc)
         routine = ProjectRoutineDatabase(
             project_id=project_id,

--- a/restai/db/projects.py
+++ b/restai/db/projects.py
@@ -5,24 +5,19 @@ Split out of the former monolithic restai/database.py. Each method still uses
 composes these mixins, so the public API is unchanged.
 """
 
+import logging
 import json
 from datetime import datetime, timezone
-from typing import Optional, List
+from typing import Optional
 
-from sqlalchemy import func, or_
+from sqlalchemy import func
 
 from restai.models.databasemodels import (
-    ApiKeyDatabase, LLMDatabase, EmbeddingDatabase, OutputDatabase, ProjectDatabase,
-    ProjectToolDatabase, ProjectRoutineDatabase, CronLogDatabase, SettingDatabase,
-    UserDatabase, TeamDatabase, TeamImageGeneratorDatabase, TeamAudioGeneratorDatabase,
-    WidgetDatabase, ImageGeneratorDatabase, SpeechToTextDatabase, ProjectSecretDatabase,
+    ProjectDatabase,
 )
 from restai.models.models import (
-    LLMModel, LLMUpdate, ProjectModelUpdate, User, UserUpdate, EmbeddingModel,
-    EmbeddingUpdate, TeamModel, TeamModelUpdate, TeamModelCreate,
+    ProjectModelUpdate,
 )
-from restai.utils.crypto import decrypt_api_key, hash_api_key, verify_api_key_hash
-from restai.db.passwords import hash_password, verify_password
 
 
 class ProjectMixin:

--- a/restai/db/runtime_activity.py
+++ b/restai/db/runtime_activity.py
@@ -5,31 +5,18 @@ Split out of the former monolithic restai/database.py. Each method still uses
 composes these mixins, so the public API is unchanged.
 """
 
-import json
 from datetime import datetime, timezone
-from typing import Optional, List
 
-from sqlalchemy import func, or_
 
 from restai.models.databasemodels import (
-    ApiKeyDatabase, LLMDatabase, EmbeddingDatabase, OutputDatabase, ProjectDatabase,
-    ProjectToolDatabase, ProjectRoutineDatabase, CronLogDatabase, SettingDatabase,
-    UserDatabase, TeamDatabase, TeamImageGeneratorDatabase, TeamAudioGeneratorDatabase,
-    WidgetDatabase, ImageGeneratorDatabase, SpeechToTextDatabase, ProjectSecretDatabase,
+    CronLogDatabase,
 )
-from restai.models.models import (
-    LLMModel, LLMUpdate, ProjectModelUpdate, User, UserUpdate, EmbeddingModel,
-    EmbeddingUpdate, TeamModel, TeamModelUpdate, TeamModelCreate,
-)
-from restai.utils.crypto import decrypt_api_key, hash_api_key, verify_api_key_hash
-from restai.db.passwords import hash_password, verify_password
 
 
 class RuntimeActivityMixin:
     __slots__ = ()
 
     def create_cron_log(self, job, status, message, details=None, items_processed=0, duration_ms=None):
-        from datetime import datetime, timezone
         entry = CronLogDatabase(
             job=job,
             status=status,
@@ -55,7 +42,6 @@ class RuntimeActivityMixin:
         """Bump `last_activity` for a chat's Docker container. Called on
         every `DockerManager.exec_command`. Multi-server safe — the
         cleanup cron reads from this table instead of in-memory state."""
-        from datetime import datetime, timezone
         from restai.models.databasemodels import DockerChatActivityDatabase
         if not chat_id:
             return
@@ -105,7 +91,6 @@ class RuntimeActivityMixin:
         """Bump `last_activity` for a chat's browser container. Called
         on every `browser.runtime.call()`. Cleanup cron reads from this
         table so eviction reflects real idle time, not container age."""
-        from datetime import datetime, timezone
         from restai.models.databasemodels import BrowserChatActivityDatabase
         if not chat_id:
             return

--- a/restai/db/settings.py
+++ b/restai/db/settings.py
@@ -5,24 +5,12 @@ Split out of the former monolithic restai/database.py. Each method still uses
 composes these mixins, so the public API is unchanged.
 """
 
-import json
-from datetime import datetime, timezone
-from typing import Optional, List
+from typing import Optional
 
-from sqlalchemy import func, or_
 
 from restai.models.databasemodels import (
-    ApiKeyDatabase, LLMDatabase, EmbeddingDatabase, OutputDatabase, ProjectDatabase,
-    ProjectToolDatabase, ProjectRoutineDatabase, CronLogDatabase, SettingDatabase,
-    UserDatabase, TeamDatabase, TeamImageGeneratorDatabase, TeamAudioGeneratorDatabase,
-    WidgetDatabase, ImageGeneratorDatabase, SpeechToTextDatabase, ProjectSecretDatabase,
+    SettingDatabase,
 )
-from restai.models.models import (
-    LLMModel, LLMUpdate, ProjectModelUpdate, User, UserUpdate, EmbeddingModel,
-    EmbeddingUpdate, TeamModel, TeamModelUpdate, TeamModelCreate,
-)
-from restai.utils.crypto import decrypt_api_key, hash_api_key, verify_api_key_hash
-from restai.db.passwords import hash_password, verify_password
 
 
 class SettingMixin:

--- a/restai/db/teams.py
+++ b/restai/db/teams.py
@@ -5,25 +5,19 @@ Split out of the former monolithic restai/database.py. Each method still uses
 composes these mixins, so the public API is unchanged.
 """
 
-import json
 from datetime import datetime, timezone
 from typing import Optional, List
 
 from sqlalchemy import func, or_
 
 from restai.models.databasemodels import (
-    ApiKeyDatabase, LLMDatabase, EmbeddingDatabase, OutputDatabase, ProjectDatabase,
-    ProjectToolDatabase, ProjectRoutineDatabase, CronLogDatabase, SettingDatabase,
+    LLMDatabase, EmbeddingDatabase, OutputDatabase, ProjectDatabase,
     UserDatabase, TeamDatabase, TeamImageGeneratorDatabase, TeamAudioGeneratorDatabase,
-    WidgetDatabase, ImageGeneratorDatabase, SpeechToTextDatabase, ProjectSecretDatabase,
     TeamUserBudgetDatabase, TeamBalanceTransactionDatabase,
 )
 from restai.models.models import (
-    LLMModel, LLMUpdate, ProjectModelUpdate, User, UserUpdate, EmbeddingModel,
-    EmbeddingUpdate, TeamModel, TeamModelUpdate, TeamModelCreate,
+    TeamModelUpdate, TeamModelCreate,
 )
-from restai.utils.crypto import decrypt_api_key, hash_api_key, verify_api_key_hash
-from restai.db.passwords import hash_password, verify_password
 
 
 class TeamMixin:

--- a/restai/db/users.py
+++ b/restai/db/users.py
@@ -7,22 +7,17 @@ composes these mixins, so the public API is unchanged.
 
 import json
 from datetime import datetime, timezone
-from typing import Optional, List
+from typing import Optional
 
-from sqlalchemy import func, or_
 
 from restai.models.databasemodels import (
-    ApiKeyDatabase, LLMDatabase, EmbeddingDatabase, OutputDatabase, ProjectDatabase,
-    ProjectToolDatabase, ProjectRoutineDatabase, CronLogDatabase, SettingDatabase,
-    UserDatabase, TeamDatabase, TeamImageGeneratorDatabase, TeamAudioGeneratorDatabase,
-    WidgetDatabase, ImageGeneratorDatabase, SpeechToTextDatabase, ProjectSecretDatabase,
+    ApiKeyDatabase, UserDatabase,
 )
 from restai.models.models import (
-    LLMModel, LLMUpdate, ProjectModelUpdate, User, UserUpdate, EmbeddingModel,
-    EmbeddingUpdate, TeamModel, TeamModelUpdate, TeamModelCreate,
+    User, UserUpdate,
 )
-from restai.utils.crypto import decrypt_api_key, hash_api_key, verify_api_key_hash
-from restai.db.passwords import hash_password, verify_password
+from restai.utils.crypto import decrypt_api_key, verify_api_key_hash
+from restai.db.passwords import hash_password
 
 
 class UserMixin:

--- a/restai/db/widgets.py
+++ b/restai/db/widgets.py
@@ -5,24 +5,13 @@ Split out of the former monolithic restai/database.py. Each method still uses
 composes these mixins, so the public API is unchanged.
 """
 
-import json
 from datetime import datetime, timezone
-from typing import Optional, List
 
-from sqlalchemy import func, or_
 
 from restai.models.databasemodels import (
-    ApiKeyDatabase, LLMDatabase, EmbeddingDatabase, OutputDatabase, ProjectDatabase,
-    ProjectToolDatabase, ProjectRoutineDatabase, CronLogDatabase, SettingDatabase,
-    UserDatabase, TeamDatabase, TeamImageGeneratorDatabase, TeamAudioGeneratorDatabase,
-    WidgetDatabase, ImageGeneratorDatabase, SpeechToTextDatabase, ProjectSecretDatabase,
+    WidgetDatabase,
 )
-from restai.models.models import (
-    LLMModel, LLMUpdate, ProjectModelUpdate, User, UserUpdate, EmbeddingModel,
-    EmbeddingUpdate, TeamModel, TeamModelUpdate, TeamModelCreate,
-)
-from restai.utils.crypto import decrypt_api_key, hash_api_key, verify_api_key_hash
-from restai.db.passwords import hash_password, verify_password
+from restai.utils.crypto import verify_api_key_hash
 
 
 class WidgetMixin:

--- a/restai/document/runner.py
+++ b/restai/document/runner.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from torch.multiprocessing import Process
-from ilock import ILock
 from llama_index.readers.docling import DoclingReader
 import torch
 

--- a/restai/eval.py
+++ b/restai/eval.py
@@ -3,7 +3,6 @@ import json
 import logging
 import time
 from datetime import datetime, timezone
-from typing import Optional
 
 # Hard ceiling on a single test case's answer generation. A wedged project
 # LLM (e.g. an upstream provider hanging) must not leave the whole run stuck

--- a/restai/helper.py
+++ b/restai/helper.py
@@ -1,11 +1,9 @@
 import time
 import socket
 import ipaddress
-from typing import AsyncGenerator, Any, Dict
 from urllib.parse import urljoin, urlparse, urlunparse
 
 from starlette.responses import StreamingResponse
-from requests import Response
 from fastapi import BackgroundTasks
 from restai.database import DBWrapper
 from restai.project import Project
@@ -26,7 +24,7 @@ from restai.config import LOG_LEVEL
 import json
 
 from restai.projects.base import ProjectBase
-from restai.limits.budget import enforce_cost_budgets, check_rate_limit, check_api_key_quota, record_api_key_tokens
+from restai.limits.budget import enforce_cost_budgets, check_rate_limit, check_api_key_quota
 from restai.models.databasemodels import ApiKeyDatabase
 
 logging.basicConfig(level=LOG_LEVEL)

--- a/restai/image/runner.py
+++ b/restai/image/runner.py
@@ -1,4 +1,3 @@
-from torch.multiprocessing import Process
 from ilock import ILock
 import tempfile
 import os
@@ -6,7 +5,6 @@ import subprocess
 import sys
 import pickle
 
-from restai.models.models import ImageModel
 
 def generate(manager, worker, imageModel, options: dict = None, venv_python: str = None):
     sharedmem = manager.dict()
@@ -71,5 +69,5 @@ def generate(manager, worker, imageModel, options: dict = None, venv_python: str
     finally:
         try:
             os.unlink(sharedmem_file.name)
-        except:
+        except Exception:
             pass

--- a/restai/image/workers/flux2.py
+++ b/restai/image/workers/flux2.py
@@ -23,7 +23,6 @@ def worker(prompt, sharedmem):
     import io
     import torch
     from diffusers import Flux2Pipeline, AutoModel
-    from diffusers.utils import load_image
     from transformers import Mistral3ForConditionalGeneration
     from PIL import Image
 

--- a/restai/integrations/oauth.py
+++ b/restai/integrations/oauth.py
@@ -70,7 +70,6 @@ class OAuthManager:
         if not sub:
             logging.warning(f"OAuth callback failed, sub is missing: {user_data}")
             raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)
-        provider_sub = f"{provider}@{sub}"
         email_claim = config.OAUTH_EMAIL_CLAIM
         email = user_data.get(email_claim, "")
         if not email:

--- a/restai/integrations/sync.py
+++ b/restai/integrations/sync.py
@@ -160,7 +160,6 @@ def _sync_s3(project, source, db, brain=None):
         except Exception as e:
             logger.warning(f"Failed to delete old S3 chunks for '{source.name}': {e}")
 
-    from restai.vectordb.tools import index_documents_classic
     n_chunks = index_documents_classic(project, all_documents, source.splitter, source.chunks)
     project.vector.save()
     _extract_entities_for_documents(project, all_documents, db, brain)

--- a/restai/limits/retention.py
+++ b/restai/limits/retention.py
@@ -1,7 +1,6 @@
 import logging
 from datetime import datetime, timedelta, timezone
 
-from restai import config
 from restai.database import DBWrapper
 from restai.models.databasemodels import (
     OutputDatabase,

--- a/restai/llms/ollamamultimodal.py
+++ b/restai/llms/ollamamultimodal.py
@@ -4,12 +4,8 @@ from pydantic import Field
 from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponseGen,
-    CompletionResponse,
-    CompletionResponseGen,
     MessageRole,
 )
-from llama_index.core.schema import ImageNode
-from llama_index.core.base.llms.types import ImageBlock, TextBlock
 from llama_index.multi_modal_llms.ollama import OllamaMultiModal
 
 

--- a/restai/llms/tools/calculator.py
+++ b/restai/llms/tools/calculator.py
@@ -1,6 +1,5 @@
 import ast
 import operator
-from typing import Optional
 
 
 # The calculator runs UNSANDBOXED in the RESTai worker, so `**` must be bounded:

--- a/restai/llms/tools/data_parser.py
+++ b/restai/llms/tools/data_parser.py
@@ -15,8 +15,6 @@ def data_parser(
         query (Optional[str]): Dot-path query for JSON (e.g. "users.0.name", "items.*.price") or column name for CSV (e.g. "name" to extract that column, "name=John" to filter rows where name equals John).
     """
     import json
-    import csv
-    from io import StringIO
 
     try:
         if format == "json":

--- a/restai/llms/tools/datetime_tool.py
+++ b/restai/llms/tools/datetime_tool.py
@@ -16,7 +16,7 @@ def datetime_tool(
         date (Optional[str]): Date string in YYYY-MM-DD format. Used with "add", "weekday", and "diff" actions.
         days (Optional[int]): Number of days to add (positive) or subtract (negative). Used with "add" action.
     """
-    from datetime import datetime, timedelta, timezone as tz
+    from datetime import datetime, timedelta
     import zoneinfo
 
     try:

--- a/restai/main.py
+++ b/restai/main.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 import warnings
 warnings.filterwarnings("ignore", message=".*Accessing the 'model_fields' attribute on the instance is deprecated.*")
 

--- a/restai/memory/bank/compress.py
+++ b/restai/memory/bank/compress.py
@@ -67,7 +67,7 @@ def _rollup(
         .filter(
             ProjectMemoryBankEntryDatabase.project_id == project_id,
             ProjectMemoryBankEntryDatabase.granularity == from_granularity,
-            ProjectMemoryBankEntryDatabase.last_source_at != None,
+            ProjectMemoryBankEntryDatabase.last_source_at.isnot(None),
             ProjectMemoryBankEntryDatabase.last_source_at < cutoff,
         )
         .all()

--- a/restai/models/models.py
+++ b/restai/models/models.py
@@ -2,11 +2,10 @@ import os
 import re
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
-from typing import Any, Dict, List, Literal, Optional, Union, Iterable
+from typing import Any, Dict, List, Literal, Optional, Union
 import json
 from datetime import datetime
 
-from restai import config
 
 _SAFE_NAME_RE = re.compile(r'^[a-zA-Z0-9._:-]+$')
 
@@ -1807,7 +1806,6 @@ class SettingsUpdate(BaseModel):
         "example": {
             "app_name": "My AI Platform",
             "hide_branding": True,
-            "currency": "USD",
             "currency": "USD"
         }
     })

--- a/restai/observability/cron_log.py
+++ b/restai/observability/cron_log.py
@@ -133,7 +133,6 @@ class CronLogger:
             finally:
                 db.db.close()
         except Exception:
-            import logging
             logging.getLogger(__name__).warning(
                 "Failed to write cron log to DB for job '%s'", self.job
             )

--- a/restai/observability/telemetry.py
+++ b/restai/observability/telemetry.py
@@ -11,8 +11,6 @@ import asyncio
 import logging
 import platform
 import sys
-import time
-import uuid
 
 import httpx
 

--- a/restai/projects/_llamaindex_loop.py
+++ b/restai/projects/_llamaindex_loop.py
@@ -42,15 +42,6 @@ def _resolve_llm(project: Project, agent_self, db: DBWrapper):
 
 def _wrap_project_tool_as_function_tool(tool_row, brain) -> FunctionTool:
     """ProjectToolDatabase row → FunctionTool; runs user code in per-chat Docker sandbox."""
-    try:
-        schema = (
-            _json.loads(tool_row.parameters)
-            if isinstance(tool_row.parameters, str)
-            else (tool_row.parameters or {"type": "object", "properties": {}, "required": []})
-        )
-    except (_json.JSONDecodeError, TypeError):
-        schema = {"type": "object", "properties": {}, "required": []}
-
     tool_code = tool_row.code
     tool_name = tool_row.name
     tool_desc = tool_row.description or tool_name
@@ -356,7 +347,6 @@ async def _drive(project, db, agent_self, *, prompt_text: str, system_prompt: st
         except Exception:
             pass
 
-    import json as _json
     _trace_tok = tokens_from_string(_json.dumps(tool_trace)) if tool_trace else 0
     yield ("result", {
         "answer": answer,

--- a/restai/projects/_openai_agents_loop.py
+++ b/restai/projects/_openai_agents_loop.py
@@ -11,7 +11,6 @@ from uuid import uuid4
 from agents import (
     Agent,
     FunctionTool,
-    ModelSettings,
     OpenAIChatCompletionsModel,
     RawResponsesStreamEvent,
     RunConfig,

--- a/restai/projects/agent.py
+++ b/restai/projects/agent.py
@@ -623,7 +623,7 @@ class Agent(ProjectBase):
                                     data_url = f"data:{mime};base64,{_b64.b64encode(data).decode('ascii')}"
                                     blocks.append(_ImgBlk.from_data_url(data_url))
                                 except Exception:
-                                    intro_lines.append(f"    (attach failed; treating as text mention)")
+                                    intro_lines.append("    (attach failed; treating as text mention)")
                             else:
                                 intro_lines.append(f"  - {name} ({mime}, {kb} KB)")
                         # Lead with text manifest for explicit image context.

--- a/restai/projects/rag.py
+++ b/restai/projects/rag.py
@@ -3,17 +3,13 @@ from typing import Optional
 
 from fastapi import HTTPException
 
-from llama_index.core.response_synthesizers import get_response_synthesizer
 from llama_index.core.retrievers import VectorIndexRetriever
-from llama_index.core.query_engine import RetrieverQueryEngine
 from llama_index.core.postprocessor import SimilarityPostprocessor
-from llama_index.core.prompts import PromptTemplate
 from llama_index.core.chat_engine import ContextChatEngine
 from llama_index.core.postprocessor.llm_rerank import LLMRerank
 from restai.chat import Chat
 from restai.database import DBWrapper
 from restai.eval import eval_rag
-from restai.limits.guard import Guard
 from restai.llm import LLM
 from restai.models.models import ChatModel, User
 from restai.project import Project

--- a/restai/routers/__init__.py
+++ b/restai/routers/__init__.py
@@ -1,1 +1,3 @@
 from . import llms, projects, tools, users, image, audio, embeddings, statistics, auth, teams
+
+__all__ = ["llms", "projects", "tools", "users", "image", "audio", "embeddings", "statistics", "auth", "teams"]

--- a/restai/routers/audio.py
+++ b/restai/routers/audio.py
@@ -1,7 +1,6 @@
 """Audio transcription endpoints."""
 import logging
 import os
-import shutil
 import subprocess
 import tempfile
 

--- a/restai/routers/auth.py
+++ b/restai/routers/auth.py
@@ -5,7 +5,6 @@ import logging
 import jwt
 import pyotp
 from fastapi import APIRouter, Depends, HTTPException, Path, Request, Response
-from fastapi.responses import RedirectResponse
 from restai import config
 from restai.auth import (
     create_access_token,
@@ -16,7 +15,7 @@ from restai.auth import (
 from restai.config import RESTAI_AUTH_SECRET
 from restai.database import DBWrapper, get_db_wrapper
 from restai.models.models import User, TOTPVerifyRequest
-from restai.utils.crypto import decrypt_totp_secret, hash_recovery_code, verify_recovery_code
+from restai.utils.crypto import decrypt_totp_secret, verify_recovery_code
 import json
 
 

--- a/restai/routers/bulk_ingest.py
+++ b/restai/routers/bulk_ingest.py
@@ -2,17 +2,15 @@
 from __future__ import annotations
 
 import os
-import shutil
 import tempfile
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Path as PathParam, Query, UploadFile
-from sqlalchemy.orm import Session
 
 from restai import config
 from restai.auth import check_not_restricted, get_current_username_project
 from restai.database import DBWrapper, get_db_wrapper
-from restai.models.databasemodels import BulkIngestJobDatabase, ProjectDatabase
+from restai.models.databasemodels import BulkIngestJobDatabase
 from restai.models.models import User, sanitize_filename
 
 

--- a/restai/routers/evals.py
+++ b/restai/routers/evals.py
@@ -14,7 +14,6 @@ from restai.models.databasemodels import (
     EvalDatasetDatabase,
     EvalTestCaseDatabase,
     EvalRunDatabase,
-    EvalResultDatabase,
     ProjectDatabase,
     PromptVersionDatabase,
 )

--- a/restai/routers/projects/_common.py
+++ b/restai/routers/projects/_common.py
@@ -1,84 +1,13 @@
-import base64
-import json
 import logging
-from typing import Optional
-import os
-import re
-import traceback
-from pathlib import Path
 from fastapi import (
     APIRouter,
-    Depends,
-    Form,
     HTTPException,
-    Path as PathParam,
-    Request,
-    UploadFile,
-    BackgroundTasks,
-    Query,
 )
-from llama_index.core.postprocessor import SimilarityPostprocessor
-from llama_index.core.retrievers import VectorIndexRetriever
-from llama_index.core.schema import Document
-from llama_index.tools.mcp import BasicMCPClient, McpToolSpec
-from unidecode import unidecode
 from restai import config
-from restai.auth import (
-    get_current_username,
-    get_current_username_project,
-    get_current_username_project_public,
-    check_not_restricted,
-    check_user_can_use_mcp_host,
-)
-from restai.database import get_db_wrapper, DBWrapper
-from restai.helper import chat_main
-from restai.loaders.url import SeleniumWebReader
-from restai.models.models import (
-    FindModel,
-    IngestResponse,
-    ProjectModel,
-    ProjectModelCreate,
-    ProjectModelUpdate,
-    ProjectResponse,
-    ProjectsResponse,
-    ProjectCommentCreate,
-    ProjectCommentUpdate,
-    ChatModel,
-    TextIngestModel,
-    URLIngestModel,
-    User,
-    WidgetCreate,
-    WidgetUpdate,
-    WidgetConfig,
-    WidgetResponse,
-    WidgetCreatedResponse,
-    BlockGenerateRequest,
-    SystemPromptGenerateRequest,
-    ProjectToolUpdate,
-    RoutineCreate,
-    RoutineUpdate,
-    validate_safe_name,
-)
-import uuid
-import secrets
-from restai.utils.crypto import encrypt_api_key, hash_api_key, encrypt_field, PROJECT_SENSITIVE_KEYS
+from restai.database import DBWrapper
+from restai.utils.crypto import PROJECT_SENSITIVE_KEYS
 from restai.brain import Brain
-from restai.project import Project
-from restai.vectordb import tools
-from restai.integrations.knowledge_graph import extract_and_persist_safe
-from restai.vectordb.tools import (
-    find_file_loader,
-    extract_keywords_for_metadata,
-    index_documents_classic,
-    index_documents_docling,
-)
-from restai.models.databasemodels import OutputDatabase, ProjectDatabase, ProjectInvitationDatabase
 from restai.settings import mask_key
-import datetime
-from sqlalchemy import func, Integer, case
-import calendar
-import tempfile
-import shutil
 
 # Mask EVERY secret in the project options blob on read (GET / list) and
 # preserve-on-mask on edit. Kept aligned with the at-rest encryption set so

--- a/restai/routers/projects/analytics.py
+++ b/restai/routers/projects/analytics.py
@@ -1,90 +1,27 @@
-import base64
-import json
 import logging
-from typing import Optional
-import os
-import re
-import traceback
-from pathlib import Path
 from fastapi import (
-    APIRouter,
     Depends,
-    Form,
     HTTPException,
     Path as PathParam,
     Request,
-    UploadFile,
-    BackgroundTasks,
     Query,
 )
-from llama_index.core.postprocessor import SimilarityPostprocessor
-from llama_index.core.retrievers import VectorIndexRetriever
-from llama_index.core.schema import Document
-from llama_index.tools.mcp import BasicMCPClient, McpToolSpec
-from unidecode import unidecode
-from restai import config
 from restai.auth import (
-    get_current_username,
     get_current_username_project,
-    get_current_username_project_public,
-    check_not_restricted,
-    check_user_can_use_mcp_host,
 )
 from restai.database import get_db_wrapper, DBWrapper
-from restai.helper import chat_main
-from restai.loaders.url import SeleniumWebReader
 from restai.models.models import (
-    FindModel,
-    IngestResponse,
-    ProjectModel,
-    ProjectModelCreate,
-    ProjectModelUpdate,
-    ProjectResponse,
-    ProjectsResponse,
-    ProjectCommentCreate,
-    ProjectCommentUpdate,
-    ChatModel,
-    TextIngestModel,
-    URLIngestModel,
     User,
-    WidgetCreate,
-    WidgetUpdate,
-    WidgetConfig,
-    WidgetResponse,
-    WidgetCreatedResponse,
-    BlockGenerateRequest,
-    SystemPromptGenerateRequest,
-    ProjectToolUpdate,
-    RoutineCreate,
-    RoutineUpdate,
     validate_safe_name,
 )
-import uuid
-import secrets
-from restai.utils.crypto import encrypt_api_key, hash_api_key, encrypt_field
-from restai.brain import Brain
-from restai.project import Project
-from restai.vectordb import tools
-from restai.integrations.knowledge_graph import extract_and_persist_safe
-from restai.vectordb.tools import (
-    find_file_loader,
-    extract_keywords_for_metadata,
-    index_documents_classic,
-    index_documents_docling,
-)
-from restai.models.databasemodels import OutputDatabase, ProjectDatabase, ProjectInvitationDatabase
-from restai.settings import mask_key
+from restai.models.databasemodels import OutputDatabase
 import datetime
-from sqlalchemy import func, Integer, case
+from sqlalchemy import func, case
 import calendar
-import tempfile
-import shutil
 
 from restai.routers.projects._common import (
     router,
     get_project,
-    _mask_sync_sources,
-    _SENSITIVE_OPTION_KEYS,
 )
 
 @router.get("/projects/{projectID}/guards/summary", tags=["Guards"])

--- a/restai/routers/projects/comments.py
+++ b/restai/routers/projects/comments.py
@@ -1,90 +1,21 @@
-import base64
-import json
-import logging
-from typing import Optional
-import os
-import re
-import traceback
-from pathlib import Path
 from fastapi import (
-    APIRouter,
     Depends,
-    Form,
     HTTPException,
     Path as PathParam,
-    Request,
-    UploadFile,
-    BackgroundTasks,
-    Query,
 )
-from llama_index.core.postprocessor import SimilarityPostprocessor
-from llama_index.core.retrievers import VectorIndexRetriever
-from llama_index.core.schema import Document
-from llama_index.tools.mcp import BasicMCPClient, McpToolSpec
-from unidecode import unidecode
-from restai import config
 from restai.auth import (
-    get_current_username,
     get_current_username_project,
-    get_current_username_project_public,
     check_not_restricted,
-    check_user_can_use_mcp_host,
 )
 from restai.database import get_db_wrapper, DBWrapper
-from restai.helper import chat_main
-from restai.loaders.url import SeleniumWebReader
 from restai.models.models import (
-    FindModel,
-    IngestResponse,
-    ProjectModel,
-    ProjectModelCreate,
-    ProjectModelUpdate,
-    ProjectResponse,
-    ProjectsResponse,
     ProjectCommentCreate,
     ProjectCommentUpdate,
-    ChatModel,
-    TextIngestModel,
-    URLIngestModel,
     User,
-    WidgetCreate,
-    WidgetUpdate,
-    WidgetConfig,
-    WidgetResponse,
-    WidgetCreatedResponse,
-    BlockGenerateRequest,
-    SystemPromptGenerateRequest,
-    ProjectToolUpdate,
-    RoutineCreate,
-    RoutineUpdate,
-    validate_safe_name,
 )
-import uuid
-import secrets
-from restai.utils.crypto import encrypt_api_key, hash_api_key, encrypt_field
-from restai.brain import Brain
-from restai.project import Project
-from restai.vectordb import tools
-from restai.integrations.knowledge_graph import extract_and_persist_safe
-from restai.vectordb.tools import (
-    find_file_loader,
-    extract_keywords_for_metadata,
-    index_documents_classic,
-    index_documents_docling,
-)
-from restai.models.databasemodels import OutputDatabase, ProjectDatabase, ProjectInvitationDatabase
-from restai.settings import mask_key
-import datetime
-from sqlalchemy import func, Integer, case
-import calendar
-import tempfile
-import shutil
 
 from restai.routers.projects._common import (
     router,
-    get_project,
-    _mask_sync_sources,
-    _SENSITIVE_OPTION_KEYS,
 )
 
 @router.get("/projects/{projectID}/comments", tags=["Comments"])

--- a/restai/routers/projects/core.py
+++ b/restai/routers/projects/core.py
@@ -1,13 +1,10 @@
 import base64
 import json
 import logging
-from typing import Optional
 import os
 import re
-import traceback
 from pathlib import Path
 from fastapi import (
-    APIRouter,
     Depends,
     Form,
     HTTPException,
@@ -39,30 +36,12 @@ from restai.models.models import (
     ProjectModel,
     ProjectModelCreate,
     ProjectModelUpdate,
-    ProjectResponse,
     ProjectsResponse,
-    ProjectCommentCreate,
-    ProjectCommentUpdate,
     ChatModel,
     TextIngestModel,
     URLIngestModel,
     User,
-    WidgetCreate,
-    WidgetUpdate,
-    WidgetConfig,
-    WidgetResponse,
-    WidgetCreatedResponse,
-    BlockGenerateRequest,
-    SystemPromptGenerateRequest,
-    ProjectToolUpdate,
-    RoutineCreate,
-    RoutineUpdate,
-    validate_safe_name,
 )
-import uuid
-import secrets
-from restai.utils.crypto import encrypt_api_key, hash_api_key, encrypt_field
-from restai.brain import Brain
 from restai.project import Project
 from restai.vectordb import tools
 from restai.integrations.knowledge_graph import extract_and_persist_safe
@@ -75,8 +54,7 @@ from restai.vectordb.tools import (
 from restai.models.databasemodels import OutputDatabase, ProjectDatabase, ProjectInvitationDatabase
 from restai.settings import mask_key
 import datetime
-from sqlalchemy import func, Integer, case
-import calendar
+from sqlalchemy import func, case
 import tempfile
 import shutil
 
@@ -223,7 +201,6 @@ async def get_projects_health(
     )
     guards = {r.project_id: {"total": r.total, "blocks": r.blocks or 0} for r in guard_rows}
 
-    from sqlalchemy import desc
     eval_rows = (
         db_wrapper.db.query(EvalRunDatabase.project_id, EvalRunDatabase.summary)
         .filter(

--- a/restai/routers/projects/kg.py
+++ b/restai/routers/projects/kg.py
@@ -1,90 +1,26 @@
-import base64
-import json
 import logging
 from typing import Optional
-import os
-import re
-import traceback
-from pathlib import Path
 from fastapi import (
-    APIRouter,
     Depends,
-    Form,
     HTTPException,
     Path as PathParam,
     Request,
-    UploadFile,
     BackgroundTasks,
     Query,
 )
-from llama_index.core.postprocessor import SimilarityPostprocessor
-from llama_index.core.retrievers import VectorIndexRetriever
-from llama_index.core.schema import Document
-from llama_index.tools.mcp import BasicMCPClient, McpToolSpec
-from unidecode import unidecode
-from restai import config
 from restai.auth import (
-    get_current_username,
     get_current_username_project,
-    get_current_username_project_public,
     check_not_restricted,
-    check_user_can_use_mcp_host,
 )
 from restai.database import get_db_wrapper, DBWrapper
-from restai.helper import chat_main
-from restai.loaders.url import SeleniumWebReader
 from restai.models.models import (
-    FindModel,
-    IngestResponse,
-    ProjectModel,
-    ProjectModelCreate,
-    ProjectModelUpdate,
-    ProjectResponse,
-    ProjectsResponse,
-    ProjectCommentCreate,
-    ProjectCommentUpdate,
-    ChatModel,
-    TextIngestModel,
-    URLIngestModel,
     User,
-    WidgetCreate,
-    WidgetUpdate,
-    WidgetConfig,
-    WidgetResponse,
-    WidgetCreatedResponse,
-    BlockGenerateRequest,
-    SystemPromptGenerateRequest,
-    ProjectToolUpdate,
-    RoutineCreate,
-    RoutineUpdate,
-    validate_safe_name,
 )
-import uuid
-import secrets
-from restai.utils.crypto import encrypt_api_key, hash_api_key, encrypt_field
-from restai.brain import Brain
-from restai.project import Project
-from restai.vectordb import tools
-from restai.integrations.knowledge_graph import extract_and_persist_safe
-from restai.vectordb.tools import (
-    find_file_loader,
-    extract_keywords_for_metadata,
-    index_documents_classic,
-    index_documents_docling,
-)
-from restai.models.databasemodels import OutputDatabase, ProjectDatabase, ProjectInvitationDatabase
-from restai.settings import mask_key
 import datetime
-from sqlalchemy import func, Integer, case
-import calendar
-import tempfile
-import shutil
 
 from restai.routers.projects._common import (
     router,
     get_project,
-    _mask_sync_sources,
-    _SENSITIVE_OPTION_KEYS,
 )
 
 @router.get("/projects/{projectID}/kg/entities", tags=["Knowledge Graph"])

--- a/restai/routers/projects/memory.py
+++ b/restai/routers/projects/memory.py
@@ -1,90 +1,21 @@
-import base64
 import json
-import logging
-from typing import Optional
-import os
-import re
-import traceback
-from pathlib import Path
 from fastapi import (
-    APIRouter,
     Depends,
-    Form,
     HTTPException,
     Path as PathParam,
     Request,
-    UploadFile,
-    BackgroundTasks,
-    Query,
 )
-from llama_index.core.postprocessor import SimilarityPostprocessor
-from llama_index.core.retrievers import VectorIndexRetriever
-from llama_index.core.schema import Document
-from llama_index.tools.mcp import BasicMCPClient, McpToolSpec
-from unidecode import unidecode
-from restai import config
 from restai.auth import (
-    get_current_username,
     get_current_username_project,
-    get_current_username_project_public,
     check_not_restricted,
-    check_user_can_use_mcp_host,
 )
 from restai.database import get_db_wrapper, DBWrapper
-from restai.helper import chat_main
-from restai.loaders.url import SeleniumWebReader
 from restai.models.models import (
-    FindModel,
-    IngestResponse,
-    ProjectModel,
-    ProjectModelCreate,
-    ProjectModelUpdate,
-    ProjectResponse,
-    ProjectsResponse,
-    ProjectCommentCreate,
-    ProjectCommentUpdate,
-    ChatModel,
-    TextIngestModel,
-    URLIngestModel,
     User,
-    WidgetCreate,
-    WidgetUpdate,
-    WidgetConfig,
-    WidgetResponse,
-    WidgetCreatedResponse,
-    BlockGenerateRequest,
-    SystemPromptGenerateRequest,
-    ProjectToolUpdate,
-    RoutineCreate,
-    RoutineUpdate,
-    validate_safe_name,
 )
-import uuid
-import secrets
-from restai.utils.crypto import encrypt_api_key, hash_api_key, encrypt_field
-from restai.brain import Brain
-from restai.project import Project
-from restai.vectordb import tools
-from restai.integrations.knowledge_graph import extract_and_persist_safe
-from restai.vectordb.tools import (
-    find_file_loader,
-    extract_keywords_for_metadata,
-    index_documents_classic,
-    index_documents_docling,
-)
-from restai.models.databasemodels import OutputDatabase, ProjectDatabase, ProjectInvitationDatabase
-from restai.settings import mask_key
-import datetime
-from sqlalchemy import func, Integer, case
-import calendar
-import tempfile
-import shutil
 
 from restai.routers.projects._common import (
     router,
-    get_project,
-    _mask_sync_sources,
-    _SENSITIVE_OPTION_KEYS,
 )
 
 @router.get("/projects/{projectID}/memory-bank", tags=["Memory Bank"])

--- a/restai/routers/projects/mobile.py
+++ b/restai/routers/projects/mobile.py
@@ -1,90 +1,24 @@
-import base64
 import json
-import logging
 from typing import Optional
-import os
-import re
-import traceback
-from pathlib import Path
 from fastapi import (
-    APIRouter,
     Depends,
-    Form,
     HTTPException,
     Path as PathParam,
     Request,
-    UploadFile,
-    BackgroundTasks,
-    Query,
 )
-from llama_index.core.postprocessor import SimilarityPostprocessor
-from llama_index.core.retrievers import VectorIndexRetriever
-from llama_index.core.schema import Document
-from llama_index.tools.mcp import BasicMCPClient, McpToolSpec
-from unidecode import unidecode
 from restai import config
 from restai.auth import (
-    get_current_username,
     get_current_username_project,
-    get_current_username_project_public,
     check_not_restricted,
-    check_user_can_use_mcp_host,
 )
 from restai.database import get_db_wrapper, DBWrapper
-from restai.helper import chat_main
-from restai.loaders.url import SeleniumWebReader
 from restai.models.models import (
-    FindModel,
-    IngestResponse,
-    ProjectModel,
-    ProjectModelCreate,
-    ProjectModelUpdate,
-    ProjectResponse,
-    ProjectsResponse,
-    ProjectCommentCreate,
-    ProjectCommentUpdate,
-    ChatModel,
-    TextIngestModel,
-    URLIngestModel,
     User,
-    WidgetCreate,
-    WidgetUpdate,
-    WidgetConfig,
-    WidgetResponse,
-    WidgetCreatedResponse,
-    BlockGenerateRequest,
-    SystemPromptGenerateRequest,
-    ProjectToolUpdate,
-    RoutineCreate,
-    RoutineUpdate,
-    validate_safe_name,
 )
-import uuid
-import secrets
-from restai.utils.crypto import encrypt_api_key, hash_api_key, encrypt_field
-from restai.brain import Brain
-from restai.project import Project
-from restai.vectordb import tools
-from restai.integrations.knowledge_graph import extract_and_persist_safe
-from restai.vectordb.tools import (
-    find_file_loader,
-    extract_keywords_for_metadata,
-    index_documents_classic,
-    index_documents_docling,
-)
-from restai.models.databasemodels import OutputDatabase, ProjectDatabase, ProjectInvitationDatabase
-from restai.settings import mask_key
-import datetime
-from sqlalchemy import func, Integer, case
-import calendar
-import tempfile
-import shutil
+from restai.utils.crypto import encrypt_api_key, hash_api_key
 
 from restai.routers.projects._common import (
     router,
-    get_project,
-    _mask_sync_sources,
-    _SENSITIVE_OPTION_KEYS,
 )
 
 def _mobile_default_host(request: Request) -> str:
@@ -156,7 +90,6 @@ def _mint_mobile_api_key(db_wrapper: DBWrapper, user, project_db) -> tuple:
     """Create a read-only project-scoped API key; returns (row, plaintext)."""
     import uuid as _uuid
     import secrets as _secrets
-    from restai.utils.crypto import encrypt_api_key, hash_api_key
 
     plaintext = _uuid.uuid4().hex + _secrets.token_urlsafe(32)
     encrypted = encrypt_api_key(plaintext)

--- a/restai/routers/projects/prompts.py
+++ b/restai/routers/projects/prompts.py
@@ -1,90 +1,21 @@
-import base64
-import json
-import logging
-from typing import Optional
-import os
-import re
-import traceback
-from pathlib import Path
 from fastapi import (
-    APIRouter,
     Depends,
-    Form,
     HTTPException,
     Path as PathParam,
     Request,
-    UploadFile,
-    BackgroundTasks,
-    Query,
 )
-from llama_index.core.postprocessor import SimilarityPostprocessor
-from llama_index.core.retrievers import VectorIndexRetriever
-from llama_index.core.schema import Document
-from llama_index.tools.mcp import BasicMCPClient, McpToolSpec
-from unidecode import unidecode
-from restai import config
 from restai.auth import (
-    get_current_username,
     get_current_username_project,
-    get_current_username_project_public,
     check_not_restricted,
-    check_user_can_use_mcp_host,
 )
 from restai.database import get_db_wrapper, DBWrapper
-from restai.helper import chat_main
-from restai.loaders.url import SeleniumWebReader
 from restai.models.models import (
-    FindModel,
-    IngestResponse,
-    ProjectModel,
-    ProjectModelCreate,
     ProjectModelUpdate,
-    ProjectResponse,
-    ProjectsResponse,
-    ProjectCommentCreate,
-    ProjectCommentUpdate,
-    ChatModel,
-    TextIngestModel,
-    URLIngestModel,
     User,
-    WidgetCreate,
-    WidgetUpdate,
-    WidgetConfig,
-    WidgetResponse,
-    WidgetCreatedResponse,
-    BlockGenerateRequest,
-    SystemPromptGenerateRequest,
-    ProjectToolUpdate,
-    RoutineCreate,
-    RoutineUpdate,
-    validate_safe_name,
 )
-import uuid
-import secrets
-from restai.utils.crypto import encrypt_api_key, hash_api_key, encrypt_field
-from restai.brain import Brain
-from restai.project import Project
-from restai.vectordb import tools
-from restai.integrations.knowledge_graph import extract_and_persist_safe
-from restai.vectordb.tools import (
-    find_file_loader,
-    extract_keywords_for_metadata,
-    index_documents_classic,
-    index_documents_docling,
-)
-from restai.models.databasemodels import OutputDatabase, ProjectDatabase, ProjectInvitationDatabase
-from restai.settings import mask_key
-import datetime
-from sqlalchemy import func, Integer, case
-import calendar
-import tempfile
-import shutil
 
 from restai.routers.projects._common import (
     router,
-    get_project,
-    _mask_sync_sources,
-    _SENSITIVE_OPTION_KEYS,
 )
 
 @router.get("/projects/{projectID}/prompts", tags=["Projects"])
@@ -132,7 +63,6 @@ async def activate_prompt_version(
     if project is None:
         raise HTTPException(status_code=404, detail="Project not found")
 
-    from restai.models.models import ProjectModelUpdate
     update = ProjectModelUpdate(system=version.system_prompt)
     update._user_id = user.id
     db_wrapper.edit_project(projectID, update)

--- a/restai/routers/projects/routines.py
+++ b/restai/routers/projects/routines.py
@@ -1,90 +1,27 @@
-import base64
-import json
 import logging
-from typing import Optional
-import os
-import re
-import traceback
-from pathlib import Path
 from fastapi import (
-    APIRouter,
     Depends,
-    Form,
     HTTPException,
     Path as PathParam,
     Request,
-    UploadFile,
     BackgroundTasks,
     Query,
 )
-from llama_index.core.postprocessor import SimilarityPostprocessor
-from llama_index.core.retrievers import VectorIndexRetriever
-from llama_index.core.schema import Document
-from llama_index.tools.mcp import BasicMCPClient, McpToolSpec
-from unidecode import unidecode
-from restai import config
 from restai.auth import (
-    get_current_username,
     get_current_username_project,
-    get_current_username_project_public,
     check_not_restricted,
-    check_user_can_use_mcp_host,
 )
 from restai.database import get_db_wrapper, DBWrapper
 from restai.helper import chat_main
-from restai.loaders.url import SeleniumWebReader
 from restai.models.models import (
-    FindModel,
-    IngestResponse,
-    ProjectModel,
-    ProjectModelCreate,
-    ProjectModelUpdate,
-    ProjectResponse,
-    ProjectsResponse,
-    ProjectCommentCreate,
-    ProjectCommentUpdate,
     ChatModel,
-    TextIngestModel,
-    URLIngestModel,
     User,
-    WidgetCreate,
-    WidgetUpdate,
-    WidgetConfig,
-    WidgetResponse,
-    WidgetCreatedResponse,
-    BlockGenerateRequest,
-    SystemPromptGenerateRequest,
-    ProjectToolUpdate,
     RoutineCreate,
     RoutineUpdate,
-    validate_safe_name,
 )
-import uuid
-import secrets
-from restai.utils.crypto import encrypt_api_key, hash_api_key, encrypt_field
-from restai.brain import Brain
-from restai.project import Project
-from restai.vectordb import tools
-from restai.integrations.knowledge_graph import extract_and_persist_safe
-from restai.vectordb.tools import (
-    find_file_loader,
-    extract_keywords_for_metadata,
-    index_documents_classic,
-    index_documents_docling,
-)
-from restai.models.databasemodels import OutputDatabase, ProjectDatabase, ProjectInvitationDatabase
-from restai.settings import mask_key
-import datetime
-from sqlalchemy import func, Integer, case
-import calendar
-import tempfile
-import shutil
 
 from restai.routers.projects._common import (
     router,
-    get_project,
-    _mask_sync_sources,
-    _SENSITIVE_OPTION_KEYS,
 )
 
 # ── Project Routines (scheduled messages) ────────────────────────────────
@@ -210,7 +147,6 @@ async def fire_routine(
     if project is None:
         raise HTTPException(status_code=404, detail="Project not found")
 
-    from fastapi import BackgroundTasks
     import inspect
 
     q = ChatModel(question=routine.message)

--- a/restai/routers/projects/tools.py
+++ b/restai/routers/projects/tools.py
@@ -1,90 +1,26 @@
-import base64
 import json
-import logging
-from typing import Optional
-import os
-import re
-import traceback
-from pathlib import Path
 from fastapi import (
-    APIRouter,
     Depends,
-    Form,
     HTTPException,
     Path as PathParam,
     Request,
-    UploadFile,
-    BackgroundTasks,
-    Query,
 )
-from llama_index.core.postprocessor import SimilarityPostprocessor
-from llama_index.core.retrievers import VectorIndexRetriever
-from llama_index.core.schema import Document
-from llama_index.tools.mcp import BasicMCPClient, McpToolSpec
-from unidecode import unidecode
-from restai import config
 from restai.auth import (
-    get_current_username,
     get_current_username_project,
-    get_current_username_project_public,
     check_not_restricted,
-    check_user_can_use_mcp_host,
 )
 from restai.database import get_db_wrapper, DBWrapper
-from restai.helper import chat_main
-from restai.loaders.url import SeleniumWebReader
 from restai.models.models import (
-    FindModel,
-    IngestResponse,
-    ProjectModel,
-    ProjectModelCreate,
-    ProjectModelUpdate,
-    ProjectResponse,
-    ProjectsResponse,
-    ProjectCommentCreate,
-    ProjectCommentUpdate,
-    ChatModel,
-    TextIngestModel,
-    URLIngestModel,
     User,
-    WidgetCreate,
-    WidgetUpdate,
-    WidgetConfig,
-    WidgetResponse,
-    WidgetCreatedResponse,
     BlockGenerateRequest,
     SystemPromptGenerateRequest,
     ProjectToolUpdate,
-    RoutineCreate,
-    RoutineUpdate,
-    validate_safe_name,
 )
-import uuid
-import secrets
-from restai.utils.crypto import encrypt_api_key, hash_api_key, encrypt_field
-from restai.brain import Brain
-from restai.project import Project
-from restai.vectordb import tools
-from restai.integrations.knowledge_graph import extract_and_persist_safe
-from restai.vectordb.tools import (
-    find_file_loader,
-    extract_keywords_for_metadata,
-    index_documents_classic,
-    index_documents_docling,
-)
-from restai.models.databasemodels import OutputDatabase, ProjectDatabase, ProjectInvitationDatabase
-from restai.settings import mask_key
-import datetime
-from sqlalchemy import func, Integer, case
-import calendar
-import tempfile
-import shutil
+from restai.models.databasemodels import ProjectDatabase
 
 from restai.routers.projects._common import (
     router,
     get_project,
-    _mask_sync_sources,
-    _SENSITIVE_OPTION_KEYS,
 )
 
 @router.get("/projects/{projectID}/custom-tools", tags=["Projects"])

--- a/restai/routers/projects/widgets.py
+++ b/restai/routers/projects/widgets.py
@@ -1,90 +1,28 @@
-import base64
 import json
-import logging
-from typing import Optional
-import os
-import re
-import traceback
-from pathlib import Path
 from fastapi import (
-    APIRouter,
     Depends,
-    Form,
     HTTPException,
     Path as PathParam,
-    Request,
-    UploadFile,
-    BackgroundTasks,
-    Query,
 )
-from llama_index.core.postprocessor import SimilarityPostprocessor
-from llama_index.core.retrievers import VectorIndexRetriever
-from llama_index.core.schema import Document
-from llama_index.tools.mcp import BasicMCPClient, McpToolSpec
-from unidecode import unidecode
-from restai import config
 from restai.auth import (
-    get_current_username,
     get_current_username_project,
-    get_current_username_project_public,
     check_not_restricted,
-    check_user_can_use_mcp_host,
 )
 from restai.database import get_db_wrapper, DBWrapper
-from restai.helper import chat_main
-from restai.loaders.url import SeleniumWebReader
 from restai.models.models import (
-    FindModel,
-    IngestResponse,
-    ProjectModel,
-    ProjectModelCreate,
-    ProjectModelUpdate,
-    ProjectResponse,
-    ProjectsResponse,
-    ProjectCommentCreate,
-    ProjectCommentUpdate,
-    ChatModel,
-    TextIngestModel,
-    URLIngestModel,
     User,
     WidgetCreate,
     WidgetUpdate,
-    WidgetConfig,
     WidgetResponse,
     WidgetCreatedResponse,
-    BlockGenerateRequest,
-    SystemPromptGenerateRequest,
-    ProjectToolUpdate,
-    RoutineCreate,
-    RoutineUpdate,
-    validate_safe_name,
 )
 import uuid
 import secrets
 from restai.utils.crypto import encrypt_api_key, hash_api_key, encrypt_field
-from restai.brain import Brain
-from restai.project import Project
-from restai.vectordb import tools
-from restai.integrations.knowledge_graph import extract_and_persist_safe
-from restai.vectordb.tools import (
-    find_file_loader,
-    extract_keywords_for_metadata,
-    index_documents_classic,
-    index_documents_docling,
-)
-from restai.models.databasemodels import OutputDatabase, ProjectDatabase, ProjectInvitationDatabase
-from restai.settings import mask_key
 import datetime
-from sqlalchemy import func, Integer, case
-import calendar
-import tempfile
-import shutil
 
 from restai.routers.projects._common import (
     router,
-    get_project,
-    _mask_sync_sources,
-    _SENSITIVE_OPTION_KEYS,
 )
 
 @router.post("/projects/{projectID}/widgets", status_code=201, tags=["Widgets"])

--- a/restai/routers/settings.py
+++ b/restai/routers/settings.py
@@ -2,13 +2,12 @@ from typing import List
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 
-from restai import config
 from restai.observability.audit import _log_to_db as _audit_log
 from restai.auth import get_current_username_admin
 from restai.config import detect_gpu_info
 from restai.database import DBWrapper, get_db_wrapper
 from restai.models.models import SettingsResponse, SettingsUpdate
-from restai.settings import get_all_settings, mask_key, update_setting, reinit_oauth, _SECRET_KEYS
+from restai.settings import get_all_settings, update_setting, reinit_oauth, _SECRET_KEYS
 from restai.utils.crypto import SETTINGS_ENCRYPTED_KEYS
 
 router = APIRouter()
@@ -185,7 +184,9 @@ async def run_crons(
     _=Depends(get_current_username_admin),
 ):
     """Trigger all cron jobs now (admin only). Runs as a subprocess."""
-    import subprocess, sys, os
+    import subprocess
+    import sys
+    import os
 
     def _run():
         try:

--- a/restai/routers/teams.py
+++ b/restai/routers/teams.py
@@ -1,7 +1,7 @@
-from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query
 import logging
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import List
 
 from restai.models.models import (
     TeamBalanceUpdate,
@@ -19,7 +19,7 @@ from restai.models.models import (
 )
 from sqlalchemy import func, or_
 from sqlalchemy.orm import joinedload
-from restai.models.databasemodels import TeamDatabase, OutputDatabase, ProjectDatabase, UserDatabase, TeamInvitationDatabase, ProjectInvitationDatabase
+from restai.models.databasemodels import OutputDatabase, ProjectDatabase, UserDatabase, TeamInvitationDatabase, ProjectInvitationDatabase
 from restai.database import get_db_wrapper, DBWrapper
 from restai.auth import (
     get_current_username,

--- a/restai/routers/templates.py
+++ b/restai/routers/templates.py
@@ -1,12 +1,10 @@
 """Project template library."""
 from __future__ import annotations
 
-import json
 import logging
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Path as PathParam, Query
-from sqlalchemy.orm import Session
 
 from restai.auth import (
     check_not_restricted,
@@ -15,10 +13,7 @@ from restai.auth import (
 )
 from restai.database import DBWrapper, get_db_wrapper
 from restai.models.databasemodels import (
-    ProjectDatabase,
     ProjectTemplateDatabase,
-    TeamDatabase,
-    UserDatabase,
 )
 from restai.models.models import (
     ProjectTemplateInstantiate,

--- a/restai/routers/tools.py
+++ b/restai/routers/tools.py
@@ -1,11 +1,10 @@
 import logging
-import os
 import traceback
 
 from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import HTTPException, Request
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Optional
 from pydantic import BaseModel
 
 from restai import config

--- a/restai/routers/users.py
+++ b/restai/routers/users.py
@@ -120,7 +120,6 @@ async def ldap_auth(request: Request, form_data: UserLogin, db_wrapper: DBWrappe
         mail = str(entry[f"{LDAP_ATTRIBUTE_FOR_MAIL}"])
         if not mail or mail == "" or mail == "[]":
             raise HTTPException(400, f"User {form_data.user} does not have mail.")
-        cn = str(entry["cn"])
         user_dn = entry.entry_dn
 
         if username == form_data.user.lower():
@@ -721,7 +720,6 @@ async def get_permission_matrix(
         )
         project_ids = {p.id for p in all_projects}
 
-        from sqlalchemy import union
         members_q = db_wrapper.db.query(teams_users.c.user_id).filter(teams_users.c.team_id.in_(admin_team_ids))
         admins_q = db_wrapper.db.query(teams_admins.c.user_id).filter(teams_admins.c.team_id.in_(admin_team_ids))
         team_user_ids = {r[0] for r in members_q.union(admins_q).all()}

--- a/restai/routers/widgets.py
+++ b/restai/routers/widgets.py
@@ -143,7 +143,7 @@ async def widget_chat(
             return WidgetChatResponse(answer=str(result))
     except HTTPException:
         raise
-    except Exception as e:
+    except Exception:
         logging.exception("Widget chat failed for project %s", widget.project_id)
         return WidgetChatResponse(answer="An error occurred processing your request.", id=body.id)
 

--- a/restai/tools.py
+++ b/restai/tools.py
@@ -138,7 +138,7 @@ def load_image_generators() -> list[FunctionTool]:
     generators = []
     directory = os.path.dirname(os.path.abspath(__file__))
 
-    print(f"Loading image generators...")
+    print("Loading image generators...")
     for importer, modname, _ in pkgutil.iter_modules(
         path=[directory + "/image/workers"]
     ):
@@ -147,7 +147,7 @@ def load_image_generators() -> list[FunctionTool]:
             if inspect.isfunction(obj) and name == "worker":
                 generators.append(obj)
 
-    print(f"Loading userland image generators...")
+    print("Loading userland image generators...")
     userland_path = _userland_dir("image")
     if userland_path:
         for importer, modname, _ in pkgutil.iter_modules(path=[userland_path]):
@@ -176,7 +176,7 @@ def load_audio_generators() -> list[FunctionTool]:
     generators = []
     directory = os.path.dirname(os.path.abspath(__file__))
 
-    print(f"Loading audio generators...")
+    print("Loading audio generators...")
     for importer, modname, _ in pkgutil.iter_modules(
         path=[directory + "/audio/workers"]
     ):
@@ -185,7 +185,7 @@ def load_audio_generators() -> list[FunctionTool]:
             if inspect.isfunction(obj) and name == "worker":
                 generators.append(obj)
 
-    print(f"Loading userland audio generators...")
+    print("Loading userland audio generators...")
     userland_path = _userland_dir("audio")
     if userland_path:
         for importer, modname, _ in pkgutil.iter_modules(path=[userland_path]):
@@ -214,7 +214,7 @@ def load_tools() -> list[FunctionTool]:
     tools = []
     directory = os.path.dirname(os.path.abspath(__file__))
 
-    print(f"Loading core tools...")
+    print("Loading core tools...")
     for importer, modname, _ in pkgutil.iter_modules(path=[directory + "/llms/tools"]):
         module = __import__(f"restai.llms.tools.{modname}", fromlist="dummy")
         for name, obj in inspect.getmembers(module):

--- a/restai/utils/search_ai.py
+++ b/restai/utils/search_ai.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import Any, Optional
+from typing import Optional
 
 from sqlalchemy import or_
 

--- a/tests/test_agent2_compression.py
+++ b/tests/test_agent2_compression.py
@@ -170,7 +170,7 @@ def test_hard_truncate_drops_oldest():
         _user("C" * 1000), _assistant("D" * 1000),
         _user("short"), _assistant("reply"),
     ]
-    total_before = count_session_tokens(msgs)
+
     # Set a budget well below the total but enough for the last turn
     budget = count_session_tokens([_user("short"), _assistant("reply")]) + 50
     truncated = hard_truncate(msgs, budget, keep_n_turns=1)

--- a/tests/test_agent2_providers.py
+++ b/tests/test_agent2_providers.py
@@ -5,7 +5,6 @@ import types
 import pytest
 
 from restai.agent2.providers import (
-    Agent2UnsupportedLLMError,
     AnthropicProvider,
     OpenAIProvider,
     ProviderConfig,

--- a/tests/test_block_interpreter.py
+++ b/tests/test_block_interpreter.py
@@ -720,7 +720,6 @@ def test_procedure_ifreturn_fallthrough():
 
 def test_recursion_shallow_ok():
     """A shallow recursive procedure (factorial) computes correctly."""
-    import copy
     def _callret(arg):
         return {"type": "procedures_callreturn", "extraState": {"name": "fact"},
                 "inputs": {"ARG0": {"block": arg}}}

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -2,7 +2,6 @@
 from restai.utils.crypto import (
     LLM_SENSITIVE_KEYS,
     PROJECT_SENSITIVE_KEYS,
-    SYNC_SOURCE_SENSITIVE_KEYS,
     decrypt_field,
     decrypt_sensitive_options,
     encrypt_field,

--- a/tests/test_email_sms_tools.py
+++ b/tests/test_email_sms_tools.py
@@ -22,7 +22,6 @@ import smtplib
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from restai.utils.crypto import (
     encrypt_field,
@@ -83,8 +82,12 @@ def test_send_email_missing_recipient():
     db = _fake_db(_fake_project({}), team_obj=team)
     with patch("restai.database.open_db_wrapper", return_value=db), \
          patch("restai.utils.email._cfg") as mock_cfg:
-        mock_cfg.SMTP_HOST = ""; mock_cfg.SMTP_PORT = ""; mock_cfg.SMTP_USER = ""
-        mock_cfg.SMTP_PASSWORD = ""; mock_cfg.SMTP_FROM = ""; mock_cfg.EMAIL_DEFAULT_TO = ""
+        mock_cfg.SMTP_HOST = ""
+        mock_cfg.SMTP_PORT = ""
+        mock_cfg.SMTP_USER = ""
+        mock_cfg.SMTP_PASSWORD = ""
+        mock_cfg.SMTP_FROM = ""
+        mock_cfg.EMAIL_DEFAULT_TO = ""
         out = send_email("hi", "body", _brain=object(), _project_id=42)
     assert out.startswith("ERROR:")
     assert "recipient" in out

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -172,6 +172,6 @@ def test_llm_valid_enums_accepted(client):
         auth=("admin", RESTAI_DEFAULT_PASSWORD),
     )
     # Should not be 422 — may succeed (201) or fail for other reasons
-    assert response.status_code != 422, f"Valid LLM enums were incorrectly rejected"
+    assert response.status_code != 422, "Valid LLM enums were incorrectly rejected"
     if response.status_code == 201:
         client.delete("/llms/test-valid-llm", auth=("admin", RESTAI_DEFAULT_PASSWORD))

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -214,7 +214,6 @@ def test_guard_references_are_ids_and_survive_rename():
 def test_delete_llm_reassign_endpoint(client):
     """The DELETE endpoint refuses to orphan projects: 409 without reassign_to,
     400 for an unknown target, and repoints dependents when given a valid one."""
-    import json as _json
     from restai.database import open_db_wrapper
     from restai.models.databasemodels import ProjectDatabase
 

--- a/tests/test_login_rate_limit.py
+++ b/tests/test_login_rate_limit.py
@@ -1,5 +1,4 @@
 """Tests for login endpoint rate limiting."""
-import pytest
 from fastapi.testclient import TestClient
 
 from restai.config import RESTAI_DEFAULT_PASSWORD

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,7 +1,6 @@
 """Tests for the internal MCP server (restai/mcp.py)."""
 
 import asyncio
-import json
 import random
 import pytest
 from unittest.mock import patch, MagicMock

--- a/tests/test_moderate_content.py
+++ b/tests/test_moderate_content.py
@@ -10,7 +10,6 @@ import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 
 def _fake_project(opts: dict):

--- a/tests/test_password_age.py
+++ b/tests/test_password_age.py
@@ -8,7 +8,6 @@ we can write a backdated `password_updated_at` directly.
 """
 from __future__ import annotations
 
-import json
 import random
 from datetime import datetime, timedelta, timezone
 

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,13 +1,10 @@
 import random
-import json
 import base64
 import pytest
 from fastapi.testclient import TestClient
-from unittest.mock import patch, MagicMock
 
 from restai.config import RESTAI_DEFAULT_PASSWORD
 from restai.main import app
-from restai.models.models import ProjectModelCreate, ProjectModelUpdate, FindModel, TextIngestModel, URLIngestModel, ChatModel
 
 project_id = None
 test_team_id = None

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -8,7 +8,6 @@ team deletion, users listing isolation, project team transfer,
 input validation, and statistics isolation.
 """
 
-import base64
 import random
 from datetime import datetime, timedelta, timezone
 import pytest
@@ -897,7 +896,7 @@ def test_statistics_non_admin_only_sees_own_projects():
             projects = r.json().get("projects", [])
             project_names = [p["name"] for p in projects]
             assert projectB_name not in project_names, \
-                f"userA can see projectB in statistics"
+                "userA can see projectB in statistics"
 
 
 def test_security_cleanup(client):

--- a/tests/test_smtp_settings_smoke.py
+++ b/tests/test_smtp_settings_smoke.py
@@ -14,7 +14,8 @@ Stops short of real `smtplib.SMTP` traffic — that's covered by
 moves credentials from API → DB → resolver.
 """
 import json
-import sys; sys.setrecursionlimit(20000)
+import sys
+sys.setrecursionlimit(20000)
 import uuid
 
 from fastapi.testclient import TestClient

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -7,7 +7,6 @@ path; these tests just verify templates add the right abstraction on top.
 """
 from __future__ import annotations
 
-import json
 import random
 
 import pytest

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,12 +1,9 @@
 import random
 import pytest
-import jwt
 from fastapi.testclient import TestClient
-from unittest.mock import patch, MagicMock
 
 from restai.config import RESTAI_DEFAULT_PASSWORD
 from restai.main import app
-from restai.models.models import UserCreate, UserUpdate
 
 test_username = "test_user_" + str(random.randint(0, 1000000))
 test_admin_username = "admin"
@@ -134,7 +131,7 @@ def test_user_apikeys(client):
     )
     assert response.status_code == 201
     key2 = response.json()["api_key"]
-    key2_id = response.json()["id"]
+    assert response.json()["id"]
 
     response = client.get(
         f"/users/{test_username}/apikeys",

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -16,8 +16,7 @@ import hmac
 import json
 import threading
 import time
-from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_widget_context.py
+++ b/tests/test_widget_context.py
@@ -1,5 +1,4 @@
 """Tests for context verification and system prompt injection."""
-import json
 import time
 
 import jwt

--- a/uv.lock
+++ b/uv.lock
@@ -307,15 +307,6 @@ wheels = [
 ]
 
 [[package]]
-name = "astroid"
-version = "3.3.11"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/74/dfb75f9ccd592bbedb175d4a32fc643cf569d7c218508bfbd6ea7ef9c091/astroid-3.3.11.tar.gz", hash = "sha256:1e5a5011af2920c7c67a53f65d536d65bfa7116feeaf2354d8b94f29573bb0ce", size = 400439, upload-time = "2025-07-13T18:04:23.177Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/0f/3b8fdc946b4d9cc8cc1e8af42c4e409468c84441b933d037e101b3d72d86/astroid-3.3.11-py3-none-any.whl", hash = "sha256:54c760ae8322ece1abd213057c4b5bba7c49818853fc901ef09719a60dbf9dec", size = 275612, upload-time = "2025-07-13T18:04:21.07Z" },
-]
-
-[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -585,38 +576,6 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/b7/cb5ce4d1a382cf53c19ef06c5fc29e85f5e129b4da6527dd207d90a5b8ad/bitsandbytes-0.45.5-py3-none-manylinux_2_24_x86_64.whl", hash = "sha256:a5453f30cc6aab6ccaac364e6bf51a7808d3da5f71763dffeb6d9694c59136e4", size = 76059261, upload-time = "2025-04-07T13:32:52.573Z" },
     { url = "https://files.pythonhosted.org/packages/a6/4c/77b535e025ce780d2ada8271c1e481fb7337c1df2588a52fe1c9bd87d2e8/bitsandbytes-0.45.5-py3-none-win_amd64.whl", hash = "sha256:ed1c61b91d989d6a33fd05737d6edbf5086d8ebc89235ee632c7a19144085da2", size = 75430204, upload-time = "2025-04-07T13:32:57.553Z" },
-]
-
-[[package]]
-name = "black"
-version = "26.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "pytokens" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload-time = "2026-03-12T03:36:03.593Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/57/5f11c92861f9c92eb9dddf515530bc2d06db843e44bdcf1c83c1427824bc/black-26.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:28ef38aee69e4b12fda8dba75e21f9b4f979b490c8ac0baa7cb505369ac9e1ff", size = 1851987, upload-time = "2026-03-12T03:40:06.248Z" },
-    { url = "https://files.pythonhosted.org/packages/54/aa/340a1463660bf6831f9e39646bf774086dbd8ca7fc3cded9d59bbdf4ad0a/black-26.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bf9bf162ed91a26f1adba8efda0b573bc6924ec1408a52cc6f82cb73ec2b142c", size = 1689499, upload-time = "2026-03-12T03:40:07.642Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/01/b726c93d717d72733da031d2de10b92c9fa4c8d0c67e8a8a372076579279/black-26.3.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:474c27574d6d7037c1bc875a81d9be0a9a4f9ee95e62800dab3cfaadbf75acd5", size = 1754369, upload-time = "2026-03-12T03:40:09.279Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/09/61e91881ca291f150cfc9eb7ba19473c2e59df28859a11a88248b5cbbc4d/black-26.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:5e9d0d86df21f2e1677cc4bd090cd0e446278bcbbe49bf3659c308c3e402843e", size = 1413613, upload-time = "2026-03-12T03:40:10.943Z" },
-    { url = "https://files.pythonhosted.org/packages/16/73/544f23891b22e7efe4d8f812371ab85b57f6a01b2fc45e3ba2e52ba985b8/black-26.3.1-cp311-cp311-win_arm64.whl", hash = "sha256:9a5e9f45e5d5e1c5b5c29b3bd4265dcc90e8b92cf4534520896ed77f791f4da5", size = 1219719, upload-time = "2026-03-12T03:40:12.597Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/f8/da5eae4fc75e78e6dceb60624e1b9662ab00d6b452996046dfa9b8a6025b/black-26.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e6f89631eb88a7302d416594a32faeee9fb8fb848290da9d0a5f2903519fc1", size = 1895920, upload-time = "2026-03-12T03:40:13.921Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/9f/04e6f26534da2e1629b2b48255c264cabf5eedc5141d04516d9d68a24111/black-26.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cd2012d35b47d589cb8a16faf8a32ef7a336f56356babd9fcf70939ad1897f", size = 1718499, upload-time = "2026-03-12T03:40:15.239Z" },
-    { url = "https://files.pythonhosted.org/packages/04/91/a5935b2a63e31b331060c4a9fdb5a6c725840858c599032a6f3aac94055f/black-26.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f76ff19ec5297dd8e66eb64deda23631e642c9393ab592826fd4bdc97a4bce7", size = 1794994, upload-time = "2026-03-12T03:40:17.124Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/0a/86e462cdd311a3c2a8ece708d22aba17d0b2a0d5348ca34b40cdcbea512e/black-26.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:ddb113db38838eb9f043623ba274cfaf7d51d5b0c22ecb30afe58b1bb8322983", size = 1420867, upload-time = "2026-03-12T03:40:18.83Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/e5/22515a19cb7eaee3440325a6b0d95d2c0e88dd180cb011b12ae488e031d1/black-26.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:dfdd51fc3e64ea4f35873d1b3fb25326773d55d2329ff8449139ebaad7357efb", size = 1230124, upload-time = "2026-03-12T03:40:20.425Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/77/5728052a3c0450c53d9bb3945c4c46b91baa62b2cafab6801411b6271e45/black-26.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:855822d90f884905362f602880ed8b5df1b7e3ee7d0db2502d4388a954cc8c54", size = 1895034, upload-time = "2026-03-12T03:40:21.813Z" },
-    { url = "https://files.pythonhosted.org/packages/52/73/7cae55fdfdfbe9d19e9a8d25d145018965fe2079fa908101c3733b0c55a0/black-26.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8a33d657f3276328ce00e4d37fe70361e1ec7614da5d7b6e78de5426cb56332f", size = 1718503, upload-time = "2026-03-12T03:40:23.666Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/87/af89ad449e8254fdbc74654e6467e3c9381b61472cc532ee350d28cfdafb/black-26.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f1cd08e99d2f9317292a311dfe578fd2a24b15dbce97792f9c4d752275c1fa56", size = 1793557, upload-time = "2026-03-12T03:40:25.497Z" },
-    { url = "https://files.pythonhosted.org/packages/43/10/d6c06a791d8124b843bf325ab4ac7d2f5b98731dff84d6064eafd687ded1/black-26.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:c7e72339f841b5a237ff14f7d3880ddd0fc7f98a1199e8c4327f9a4f478c1839", size = 1422766, upload-time = "2026-03-12T03:40:27.14Z" },
-    { url = "https://files.pythonhosted.org/packages/59/4f/40a582c015f2d841ac24fed6390bd68f0fc896069ff3a886317959c9daf8/black-26.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc622538b430aa4c8c853f7f63bc582b3b8030fd8c80b70fb5fa5b834e575c2", size = 1232140, upload-time = "2026-03-12T03:40:28.882Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/0d/52d98722666d6fc6c3dd4c76df339501d6efd40e0ff95e6186a7b7f0befd/black-26.3.1-py3-none-any.whl", hash = "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b", size = 207542, upload-time = "2026-03-12T03:36:01.668Z" },
 ]
 
 [[package]]
@@ -976,6 +935,65 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ca/65/efd0fe8a936fc8ca2978cb7b82581fb20d901c6039e746a808f746b7647b/confection-1.3.3.tar.gz", hash = "sha256:f0f6810d567ff73993fe74d218ca5e1ffb6a44fb03f391257fc5d033546cbfaa", size = 54895, upload-time = "2026-03-24T18:45:24.331Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/e4/d66708bdf0d92fb4d49b22cdff4b10cec38aca5dcd7e81d909bb55c65cd7/confection-1.3.3-py3-none-any.whl", hash = "sha256:b9fef9ee84b237ef4611ec3eb5797b70e13063e6310ad9f15536373f5e313c82", size = 35902, upload-time = "2026-03-24T18:45:22.664Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.15.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d0/55fe630f4cf94e3fcba868240fad8c8cdd1f764e2a932f8926347e6ec4cd/coverage-7.15.2.tar.gz", hash = "sha256:3df60dc267f0a2ca23cb7a9ab1109c62b9335ffbf519fcfe167157c28c09b81d", size = 927741, upload-time = "2026-07-15T18:56:19.558Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/3a/54536704f507d4573bf9161c4d0dd3dd59b6d85e48c664e901b6844d8e33/coverage-7.15.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2f1ec6f304b156669cfde653b4e9a953f5de87e247ea02ac599bce0ab2744036", size = 221414, upload-time = "2026-07-15T18:53:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/d9/8ba925d29743e3577b21e4d8c11a702b76bc93c41e7fdfd1177af63d4b8d/coverage-7.15.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4d3361879d736f469f45723c11ea1a5bbdaf1f6928f0e632c940378b5aa9b660", size = 221913, upload-time = "2026-07-15T18:53:53.682Z" },
+    { url = "https://files.pythonhosted.org/packages/09/54/a855f3aa0187f2b431ade4e4791b77b56282cfb5d201c83ec26a31b5b36a/coverage-7.15.2-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c6a98d698f9e2c8008d0370ec7fc452ebfcc530002ae2d0061170d768b992589", size = 252332, upload-time = "2026-07-15T18:53:55.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d3/13ac97b4370640ba3452fc8559b06cc2f479ce3ba4a0b632a73e44c38a7d/coverage-7.15.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d50dd325e18ec25bfcc10cd7f99b04df1ab9ec76b0918c260e60817ad0643dee", size = 254243, upload-time = "2026-07-15T18:53:57.055Z" },
+    { url = "https://files.pythonhosted.org/packages/88/83/5eca144942d8d0659d3f55176517f4a59cdc65eefd17146a0770935a3ebd/coverage-7.15.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:67d7602480a47bdf5b675635403625553ebaa70d5a62a657c035149fd401cea0", size = 256352, upload-time = "2026-07-15T18:53:58.83Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ba/d3db2e01a50fc88cdb4c0f19542bcf6f61489e34dc9aa3538413e2459a38/coverage-7.15.2-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cee0f89f4767a6057c8fbf168f8135f18be651300496086bd873e3189fed0487", size = 258313, upload-time = "2026-07-15T18:54:00.497Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b3/aba83416e9177df28e5186d856c19158c59fc0e7e814aaa61a4a2354ad1b/coverage-7.15.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a29ec5305a7335aacee2d799e3422e91e1c8a12474986e2b3b07e315c91be82f", size = 252449, upload-time = "2026-07-15T18:54:02.456Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/a5/4b00ecac0194431ab451b0f6710f8e2517d04cef60f821b14dec4637d575/coverage-7.15.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:48ccc6395958eda89093ecdc35644c86f23a8b23a7f4d44958812b721aad67c1", size = 254043, upload-time = "2026-07-15T18:54:04.072Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b6/cfa209b4313ee7f1b34da47efcd789ea51c024ad35af390e00f5a3c10a2e/coverage-7.15.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:81f382c5a94b434ec1f6da607edb904c76d7212e618cd4d1bc9f97bed4120ef5", size = 252107, upload-time = "2026-07-15T18:54:06.745Z" },
+    { url = "https://files.pythonhosted.org/packages/36/67/e8cac5a6954038c98d7fe7eb9802afe7ab3ecb637bb7cc00e69b4148b56d/coverage-7.15.2-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:bbc808daf4f5cd567af8075ecc72d21c6dfef9a254709a621a84c217c935ebc0", size = 255873, upload-time = "2026-07-15T18:54:08.48Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/92/395cca9f330a86c3fe3471d73e2c102116c4c58fdc619dbbc125c6e93a54/coverage-7.15.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:a4c46b247b5d4b78f613bd89fea926d32b25c6cc61a50bd1e99ba310348f3dad", size = 251826, upload-time = "2026-07-15T18:54:10.083Z" },
+    { url = "https://files.pythonhosted.org/packages/51/60/3e91b20295439652424f426b7086ec5bf4fbe3f604c73eda22b986c4fd6b/coverage-7.15.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:094dd37f3ef7b2da8b068b583d1f4c40f91c65197e16c52a71962d5d537fc5db", size = 252735, upload-time = "2026-07-15T18:54:11.878Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/eb/8c07839005e5e3c6b3877d3a6e2a80ce766589f31dd2b6882b78d59a7b8c/coverage-7.15.2-cp311-cp311-win32.whl", hash = "sha256:a63b9e190711134d581c4d703df5df09851b1acf99792c7aacbbe9f41f0283c9", size = 223500, upload-time = "2026-07-15T18:54:13.525Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/98/59d83c257cd59f0fbaf9d9ddb26b744a576760dfd1ae16e516408894a02b/coverage-7.15.2-cp311-cp311-win_amd64.whl", hash = "sha256:8bb9f4b4279187560796a4cdaca3b0a93dd97e48ee667df005f4ed9a97403688", size = 223973, upload-time = "2026-07-15T18:54:15.163Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/09/2d285c8bef5c4f695d120c1c96dc11715638aa8e134069f210bb6a62a9fe/coverage-7.15.2-cp311-cp311-win_arm64.whl", hash = "sha256:8c726b232659cbd2ae57ade46509eb068c9bd7a06df9fcbff6fe484870006934", size = 223519, upload-time = "2026-07-15T18:54:16.803Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/50/eb5bf42e531611a9f8d272556b1ed4de503f84a91413584094487cf69f8f/coverage-7.15.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1adac78e5abc7c5438f7a209c9ca69d06542f0bf481d728b6989ea80b813fdf9", size = 221587, upload-time = "2026-07-15T18:54:18.439Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d1/da99af464c335d4e023a6efcd7ec30f63b88a43c93745154ab74ffb31cea/coverage-7.15.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b868acc62aa5de3be7a9d05c2333bf8359ca987e43f9cb30ff8fbda6a024ab73", size = 221943, upload-time = "2026-07-15T18:54:20.062Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/8a/13c42723d61ca447eafa18732e8141dd6a63f2732e1c7e1502c182dd88d7/coverage-7.15.2-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6f6966fc30e6f06ca8f98fb0ce51eda6b111b3ee8d066a8b1ec9e77fa06ab55d", size = 253450, upload-time = "2026-07-15T18:54:21.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/29/99021303f98fbdcb63504b4d07bea4cc025b9b2dd907c4f07c85d50a0dab/coverage-7.15.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:68af907f595ab01a78f794932ff3bdf929c316d3000810d38dbc247129e26f8b", size = 256187, upload-time = "2026-07-15T18:54:23.4Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/a8/fd503715ed6ca9c5d742923aa5209257340b367a867b2ced0c7d4ba8a0b9/coverage-7.15.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:afa29e2eff3d5729267e2cb2fd4ce9d61c952932fb2694e34ccb5d9540c6a296", size = 257301, upload-time = "2026-07-15T18:54:25.183Z" },
+    { url = "https://files.pythonhosted.org/packages/da/40/3f4b8fb409810036ebc2857d36adc0498c6e957b5df0290c5036b2e143f1/coverage-7.15.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bbf44513ceb1589e31948e20eafbde9deaface90e1a1afa5f5f77b4423d17ce6", size = 259562, upload-time = "2026-07-15T18:54:27.204Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/8a/9bdffbef47db77cce3d6b02a28f7e919b19f0106c4b080c2c2246040f885/coverage-7.15.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9deddf09eecb717b7f980414b43d90a5b22ff3967d2949ab29cb0aa83d9e9098", size = 253841, upload-time = "2026-07-15T18:54:29.134Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/1e/9031efde019d31a06646261fce6dfc5c3c74e951e27a71e5c9a424563178/coverage-7.15.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ae901f7e55ba405c84ee1cab3d3e962e4e871e4a2bcb9c90911adbd69b42ac5a", size = 255221, upload-time = "2026-07-15T18:54:31.142Z" },
+    { url = "https://files.pythonhosted.org/packages/56/db/787acde872389fc84a9ef9d8cd1ccc658e391ab4cb5b28092a714426a394/coverage-7.15.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a0f47002c6eeb7c280228467a4cb0cc15ca2103a8421b986b2d3ec04a0f9bd8b", size = 253366, upload-time = "2026-07-15T18:54:32.886Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/9b/6f57bc4b93c842eef1695f8cdaf2318e35e7ba54f5ba80d84be213ab7858/coverage-7.15.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1cd7a5beb7af3e864a13b1f0fb26efd3695da43ef0daf71e586adfffaf34d5b2", size = 257434, upload-time = "2026-07-15T18:54:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/88/26/b3186a21b2acc83e451118978905c81c7072c3333707804db09a78c096a2/coverage-7.15.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:97a5c5457a9fb1d6c4e06cfb5dc835871fbfb6a6a51addc9e925bdeff5ef7440", size = 252935, upload-time = "2026-07-15T18:54:36.548Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c2/c9f3376b2e717ea69ed7a6e9a5fcab968fb0b290db6cf4bd9a1fc7541b75/coverage-7.15.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0901cfe6c13bcd2302da4f83e884555d2a22bda6e4c476f09ef204ba20ca536e", size = 254807, upload-time = "2026-07-15T18:54:38.296Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e1/dfc15401f4a8aaeb486e1ba3e9e3c40522a6e38bd0ecf0b3f29cb8082957/coverage-7.15.2-cp312-cp312-win32.whl", hash = "sha256:b171bdd71cb7ff792bf32e376173b0ace7e7963e7e57c58dfc42063a6a7174cd", size = 223641, upload-time = "2026-07-15T18:54:40.103Z" },
+    { url = "https://files.pythonhosted.org/packages/91/40/81b6d809d320cd366ec5bdf8176575e897dcb8efe7fb4b489ef9e93e4d13/coverage-7.15.2-cp312-cp312-win_amd64.whl", hash = "sha256:582edc45c2040543fef83341be23c43024a3ab3ae0c2d8bc498a06282905ad40", size = 224172, upload-time = "2026-07-15T18:54:41.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/28/9f14ec438149f7de557f45518f09b4a7917b795cc37083aa7db482693f8c/coverage-7.15.2-cp312-cp312-win_arm64.whl", hash = "sha256:a638db90c61cd219aeee65e83a24fdaa57269a741ae0cf773309208ac862cee3", size = 223556, upload-time = "2026-07-15T18:54:43.674Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d5/f8c838e6b7282976f7c918884b792df7a0c42c5bba5d99c60ad2d221d56d/coverage-7.15.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1121caa19159a38b5463eaae4b1e1fde81e525b15ecc5e000cd5b1a108f743a8", size = 221606, upload-time = "2026-07-15T18:54:45.448Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/37/97c926376364f66298cc44893b89cdf17b8bc406376497c4061ae4b8a8ff/coverage-7.15.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a300c6934e0989c327b9e8a1e110329da4641149f872bbe9f70168be66da76c1", size = 221982, upload-time = "2026-07-15T18:54:47.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/30/a36050a6e83c2135ee0776f452ca3948224befc6d7f26acecc082d0c106a/coverage-7.15.2-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2617f8799d268fabdeef42a7e89ac3a23e1deee9025427db2df970f99a89a578", size = 252972, upload-time = "2026-07-15T18:54:49.2Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d3/06b5f1daf95f0f15ab05bd75f26ba5f3c8b33d0bb72f3aaa3cf41d1bad3a/coverage-7.15.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7dc2950a2992cd676d35c20ae63522836deeb034f08874699d14068710af3dc1", size = 255569, upload-time = "2026-07-15T18:54:51.098Z" },
+    { url = "https://files.pythonhosted.org/packages/81/1c/9afb3f8de2b8d36960391c48559a2e3ff96594b58099f115921549ea8d0d/coverage-7.15.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9e36686f7a442185db2400b3df171aac520869faf9deb59df687d28659eda2a6", size = 256806, upload-time = "2026-07-15T18:54:53.145Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d8/b989f96061a5e32d82fddd1b1b9ff48a7c8f8ae7606f0e80fd9de54b1e33/coverage-7.15.2-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d29ca7bd67af6e12e74632d65f026eabc1364da5c254494cd914446a28a3ef7", size = 258936, upload-time = "2026-07-15T18:54:55.015Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/fa/f99771f5110457c7b511c1935ca49ddf288218eaa84322e028b9334146ae/coverage-7.15.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:db9c8438057e5b0f6a22a0af99c0c1d26b57fbbdbd1be5861ddb8f897fcc3a2d", size = 253178, upload-time = "2026-07-15T18:54:57.527Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/96/c098a6044d119c751ceede7be91035fa8310170ec24a6523aff72f0a5793/coverage-7.15.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:63022c4c8dec1d0342f05c3ede99842fe3d007689acc45e86f123a1746e4a026", size = 254934, upload-time = "2026-07-15T18:54:59.41Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a2/1457b3a7a50c8d77500103b97a046db863e2f59a1cf6d2f814595f349885/coverage-7.15.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:6c0be82b4d4aa5b2704e08518e2252f3e3d110164bcca826816801052e48a7aa", size = 252898, upload-time = "2026-07-15T18:55:01.338Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/0e/76958874c471ecfcdde0d2b2747bb2c61bdbf34a40636f4ce9db9923e643/coverage-7.15.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4510fb9cdf6bb02dfa6af0be4a534b8102d086e22e4a33f8836df663da3d660d", size = 257056, upload-time = "2026-07-15T18:55:03.243Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/7c/3d7c4e3bf58baa40327dc7edc2272b17cf02299366d52763db1b0ca1556a/coverage-7.15.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:42ec3d989421b174a2ab607c1539f24127ad362757b7f1c0c0d7a2993f7eb37b", size = 252718, upload-time = "2026-07-15T18:55:05.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b8/1cecffed9ce14fb25be9ba42d37b6bb61485c9a3ddd43cd3dde36b6087d8/coverage-7.15.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e8f91bce78e32343af184c3b7fa28fcf5a9e2641f4b6623d392038f804939188", size = 254490, upload-time = "2026-07-15T18:55:06.889Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/2c/42984561bc7f4c045dca67516a0c50ee5ef8d84352dbeb5559dc86c4823e/coverage-7.15.2-cp313-cp313-win32.whl", hash = "sha256:434e68d531858205895eb0d74b73d20b84260de426387d53c422a5acda2cf050", size = 223647, upload-time = "2026-07-15T18:55:08.941Z" },
+    { url = "https://files.pythonhosted.org/packages/41/9f/39c7c9245efc583beddf89a87683574e663ed93637f3afb6cd7b88405676/coverage-7.15.2-cp313-cp313-win_amd64.whl", hash = "sha256:26c3b04a6377fd7c09800921fa934e3a17c0020439cd59df73e73ae1d4b6a78c", size = 224190, upload-time = "2026-07-15T18:55:10.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/de/3a2883cf8a213659280ef4b403059e17a9acaeb7fc7fd4105e1226ff2e6d/coverage-7.15.2-cp313-cp313-win_arm64.whl", hash = "sha256:3ed010aa1b69cda8e827aabfca9866216c980e2dca82ab9a78c5f83689964c8b", size = 223583, upload-time = "2026-07-15T18:55:12.678Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/82/32e3bd191d498e64f6f911ad55d14006a0861e54869d2d32452326399e65/coverage-7.15.2-py3-none-any.whl", hash = "sha256:eb6bcae8d1a9d305351ecb108232441d11c5cfe9de840a04388ba5d2db8d735c", size = 213375, upload-time = "2026-07-15T18:56:17.305Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
 ]
 
 [[package]]
@@ -2405,15 +2423,6 @@ wheels = [
 ]
 
 [[package]]
-name = "isort"
-version = "6.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1e/82/fa43935523efdfcce6abbae9da7f372b627b27142c3419fcf13bf5b0c397/isort-6.1.0.tar.gz", hash = "sha256:9b8f96a14cfee0677e78e941ff62f03769a06d412aabb9e2a90487b3b7e8d481", size = 824325, upload-time = "2025-10-01T16:26:45.027Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/cc/9b681a170efab4868a032631dea1e8446d8ec718a7f657b94d49d1a12643/isort-6.1.0-py3-none-any.whl", hash = "sha256:58d8927ecce74e5087aef019f778d4081a3b6c98f15a80ba35782ca8a2097784", size = 94329, upload-time = "2025-10-01T16:26:43.291Z" },
-]
-
-[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3742,15 +3751,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
-]
-
-[[package]]
 name = "mcp"
 version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4745,15 +4745,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pathspec"
-version = "1.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
-]
-
-[[package]]
 name = "pdfminer-six"
 version = "20251230"
 source = { registry = "https://pypi.org/simple" }
@@ -5490,24 +5481,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5d/ab/34ec41718af73c00119d0351b7a2531d2ebddb51833a36448fc7b862be60/pylatexenc-2.10.tar.gz", hash = "sha256:3dd8fd84eb46dc30bee1e23eaab8d8fb5a7f507347b23e5f38ad9675c84f40d3", size = 162597, upload-time = "2021-04-06T07:56:07.854Z" }
 
 [[package]]
-name = "pylint"
-version = "3.3.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "astroid" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "dill" },
-    { name = "isort" },
-    { name = "mccabe" },
-    { name = "platformdirs" },
-    { name = "tomlkit" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/04/9d/81c84a312d1fa8133b0db0c76148542a98349298a01747ab122f9314b04e/pylint-3.3.9.tar.gz", hash = "sha256:d312737d7b25ccf6b01cc4ac629b5dcd14a0fcf3ec392735ac70f137a9d5f83a", size = 1525946, upload-time = "2025-10-05T18:41:43.786Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/a7/69460c4a6af7575449e615144aa2205b89408dc2969b87bc3df2f262ad0b/pylint-3.3.9-py3-none-any.whl", hash = "sha256:01f9b0462c7730f94786c283f3e52a1fbdf0494bbe0971a78d7277ef46a751e7", size = 523465, upload-time = "2025-10-05T18:41:41.766Z" },
-]
-
-[[package]]
 name = "pymysql"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -5633,7 +5606,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -5642,9 +5615,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
 ]
 
 [[package]]
@@ -5658,6 +5631,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]
@@ -5786,30 +5773,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/a9/0c0db8d37b2b8a645666f7fd8accea4c6224e013c42b1d5c17c93590cd06/python_pptx-1.0.2.tar.gz", hash = "sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095", size = 10109297, upload-time = "2024-08-07T17:33:37.772Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/4f/00be2196329ebbff56ce564aa94efb0fbc828d00de250b1980de1a34ab49/python_pptx-1.0.2-py3-none-any.whl", hash = "sha256:160838e0b8565a8b1f67947675886e9fea18aa5e795db7ae531606d68e785cba", size = 472788, upload-time = "2024-08-07T17:33:28.192Z" },
-]
-
-[[package]]
-name = "pytokens"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/92/790ebe03f07b57e53b10884c329b9a1a308648fc083a6d4a39a10a28c8fc/pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440", size = 160864, upload-time = "2026-01-30T01:02:57.882Z" },
-    { url = "https://files.pythonhosted.org/packages/13/25/a4f555281d975bfdd1eba731450e2fe3a95870274da73fb12c40aeae7625/pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc", size = 248565, upload-time = "2026-01-30T01:02:59.912Z" },
-    { url = "https://files.pythonhosted.org/packages/17/50/bc0394b4ad5b1601be22fa43652173d47e4c9efbf0044c62e9a59b747c56/pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d", size = 260824, upload-time = "2026-01-30T01:03:01.471Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/54/3e04f9d92a4be4fc6c80016bc396b923d2a6933ae94b5f557c939c460ee0/pytokens-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9907d61f15bf7261d7e775bd5d7ee4d2930e04424bab1972591918497623a16", size = 264075, upload-time = "2026-01-30T01:03:04.143Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/1b/44b0326cb5470a4375f37988aea5d61b5cc52407143303015ebee94abfd6/pytokens-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:ee44d0f85b803321710f9239f335aafe16553b39106384cef8e6de40cb4ef2f6", size = 103323, upload-time = "2026-01-30T01:03:05.412Z" },
-    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
-    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
-    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
-    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
 ]
 
 [[package]]
@@ -6201,10 +6164,11 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "black" },
     { name = "debugpy" },
     { name = "fakeredis" },
-    { name = "pylint" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
 ]
 gpu = [
     { name = "accelerate" },
@@ -6319,10 +6283,11 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", specifier = ">=25.12.0,<27" },
     { name = "debugpy", specifier = ">=1.8.20,<2" },
     { name = "fakeredis", specifier = ">=2.35.1,<3" },
-    { name = "pylint", specifier = ">=3.3.0,<4" },
+    { name = "pytest", specifier = ">=8.3.0,<9" },
+    { name = "pytest-cov", specifier = ">=6.0.0,<8" },
+    { name = "ruff", specifier = ">=0.15.0,<0.16" },
 ]
 gpu = [
     { name = "accelerate", specifier = ">=1.13.0,<2" },
@@ -6457,6 +6422,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/a4/c2292b95246b9165cc43a0c3757e80995d58bc9b43da5cb47ad6e3535213/rtree-1.4.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f155bc8d6bac9dcd383481dee8c130947a4866db1d16cb6dff442329a038a0dc", size = 1555140, upload-time = "2025-08-13T19:31:58.031Z" },
     { url = "https://files.pythonhosted.org/packages/74/25/5282c8270bfcd620d3e73beb35b40ac4ab00f0a898d98ebeb41ef0989ec8/rtree-1.4.1-py3-none-win_amd64.whl", hash = "sha256:efe125f416fd27150197ab8521158662943a40f87acab8028a1aac4ad667a489", size = 389358, upload-time = "2025-08-13T19:31:59.247Z" },
     { url = "https://files.pythonhosted.org/packages/3f/50/0a9e7e7afe7339bd5e36911f0ceb15fed51945836ed803ae5afd661057fd/rtree-1.4.1-py3-none-win_arm64.whl", hash = "sha256:3d46f55729b28138e897ffef32f7ce93ac335cb67f9120125ad3742a220800f0", size = 355253, upload-time = "2025-08-13T19:32:00.296Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/06/ae069393fc66e8ff33036d4b368003833bf6e88ccf182e17e7a2f1c754fd/ruff-0.15.22.tar.gz", hash = "sha256:3f15175b1fb580126f58285a5dae6b2ea89000136d980c64499211f116b54809", size = 4785063, upload-time = "2026-07-16T15:14:13.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/18/ee54b7ae1e121be7a28ea6da4b67564ebb0530e183a54415ab7e3bcd2c4e/ruff-0.15.22-py3-none-linux_armv6l.whl", hash = "sha256:44423e73493737f5e7c5b41d475483898ff37afcdae38bc3da5085e29af1c2d8", size = 10781258, upload-time = "2026-07-16T15:13:19.452Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d2/2520cb14761ddbeaf57642a76942fc36adcbdbe53b4532241995f6fc485c/ruff-0.15.22-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b82c6482946e9eda7ff2e091d25b8bad3f718684e1916d41bd56873cee05b697", size = 10999477, upload-time = "2026-07-16T15:13:23.318Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/10/74e53572aa758dfaa678c2a2646b5c5515d884b7ca56be4d2ce03ca4b560/ruff-0.15.22-py3-none-macosx_11_0_arm64.whl", hash = "sha256:11c1c715af53a09f714e011106bffc419751ec8232fcb5da42173284ea3fec6f", size = 10466716, upload-time = "2026-07-16T15:13:26.162Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/cc/44eaaf0844e028182f2d0a8f2190d0f359159aed0a9e5ab861d892f1ae2a/ruff-0.15.22-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:742a29cf29bddb7c8327895d6a10e0e6c5b38a96dd407af9b5d0857f809c0576", size = 10892644, upload-time = "2026-07-16T15:13:29.229Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/21/8edf559014d2b0f82beea19cfb713993ad802ccda16868769979c6090a84/ruff-0.15.22-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72af58b951b0ae395935ae79763dc349bc0eb706319d28f7a33ad2cfb3cfc178", size = 10576719, upload-time = "2026-07-16T15:13:32.35Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/1e/3a13abd392a3b50b62e5938a831f9ab6e588358cacad5c18545b716d2182/ruff-0.15.22-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:62d425005c1835eb24e2ee4161cb90e8db263415f4a71c8c72c33abaa6c0c224", size = 11376494, upload-time = "2026-07-16T15:13:35.958Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3e/422d3d95bcf04dd78e1aeac22184d4f9a8fb2c01865d39d44618484a0317/ruff-0.15.22-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8b9b3f8779a4f08c969defc3c8c35abffaa757e601ed5ae66d6d1db6519969a", size = 12208370, upload-time = "2026-07-16T15:13:39.185Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/91/5d065a0e0a02bf4813f5119ad278462eed081d2b832eb7c021ade0ec9e65/ruff-0.15.22-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1e0dd1b2e4d3d585f897a0d137cbf4eaf6223bef4e8ce34d6bb12556c5f9249e", size = 11581098, upload-time = "2026-07-16T15:13:42.132Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f9/a0d4871d12fae702eb1f41b686caf05f1f8b124dc6db6f784f53d74918fa/ruff-0.15.22-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365523eb91d9224e1bcb03b022fbf0facb8f9e23792a2c53d9d4b3924bdbdebb", size = 11399422, upload-time = "2026-07-16T15:13:45.2Z" },
+    { url = "https://files.pythonhosted.org/packages/18/80/c843a5176cddbceb0b7e8dd41cf9993490796c1c469348d384f5a5c13c56/ruff-0.15.22-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:fabfd168afdf29fee5be98b831efa9683c94d7c5a3b58b9ce5a2e38444589a74", size = 11381683, upload-time = "2026-07-16T15:13:48.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/00/8485de0ae92239438a36cfc51350db9b9e85c9ebdfaea91b18e422706662/ruff-0.15.22-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:225dbf095a87f1d9f90f5fd7924d2613ee452a75a4308c63a8f50f761787aa7c", size = 10850295, upload-time = "2026-07-16T15:13:51.655Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/91/24977ec2ec72eaf15e4394ace2959fdff2dd1e14f03e005e838023407169/ruff-0.15.22-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1877d63b9d24ed278744f1523fd11b85540566d54641f97c566d7d9dc5ca5296", size = 10579640, upload-time = "2026-07-16T15:13:54.79Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/47/9b51216951974df1f263ac19da550d34252e0ed7218c25f10c5ef9ed7517/ruff-0.15.22-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a1606c510bd7215680d32efab38965f7cdec3ef69f5170a3f4791404ffdd5262", size = 11105077, upload-time = "2026-07-16T15:13:57.915Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/47/20e9d4a3b8016778acea5fc32bb50d35d207500a17ddb529ffa6996feef8/ruff-0.15.22-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:630479b18625f5ffc373f77603a22a9f8ac0acd7ff0501178b5db28ec71e9c64", size = 11490980, upload-time = "2026-07-16T15:14:01.032Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/76/3f72d8fc38c1cb77b38c56a70da9d0c17700cc1cc50f9649c9d3c8f5ba71/ruff-0.15.22-py3-none-win32.whl", hash = "sha256:e5ba0e4a13fd14abbed2a77b517a3911290c6c6c59ef67784328d1668fab76cf", size = 10789165, upload-time = "2026-07-16T15:14:04.16Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/46/4965251734c2b6fcdca1b1b187d20bcac3af0ee5b083b89c910bb961ce3a/ruff-0.15.22-py3-none-win_amd64.whl", hash = "sha256:9be63ba1eb936acd2d1342fb8337c356353706fce233b2a15a09a97037e6acde", size = 11938297, upload-time = "2026-07-16T15:14:07.316Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c9/e69b1ff4c8b69093ef08b8919ab767af0569666865b39c30a8795d88d3c6/ruff-0.15.22-py3-none-win_arm64.whl", hash = "sha256:e1168075b72158510839f250027659cdd78476f40507dd517892304c41318661", size = 11298172, upload-time = "2026-07-16T15:14:10.51Z" },
 ]
 
 [[package]]
@@ -7265,15 +7255,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
     { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
-]
-
-[[package]]
-name = "tomlkit"
-version = "0.14.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Test suite: 211s → 52s (4×), same 794 passed / 28 skipped

The suite spent most of its wall-clock re-running the FastAPI lifespan: every test module opens its own module-scoped `with TestClient(app)`, and each enter re-ran `Brain()` init (tool loading, tokenizer), settings seeding, retention cleanup, OAuth manager setup — and appended a **duplicate copy of every route** via `register_routers()`/`register_spa()` (~60× by the end of the run, slowing route matching as the suite progressed).

Changes are test-only (`tests/conftest.py`), no production code touched:
- Run the real app lifespan **once per process**; every later `TestClient` enter/exit is a no-op. Real shutdown driven at session end. pytest-xdist compatible (one startup per worker).
- Disable the anonymized-telemetry startup task during tests.
- Cheapen credential hashing for test-created creds: bcrypt cost 12 → 4, PBKDF2 100k → 1k iterations. Hash/verify stay consistent (both read the knobs at call time); externally seeded hashes (admin from `database.py`) still verify because bcrypt embeds its cost.

## Dev env: ruff + backend coverage

- **ruff** replaces pylint + black in the dev group (`make code` pointed at a nonexistent `app/` dir, so formatting was effectively dead). Config in `pyproject.toml`: default E/F rules with pragmatic ignores (`E402` late imports are load-bearing, `E712` is SQLAlchemy filter syntax, `E731`, `E741`); `migrations/` and `examples/` excluded. Repo is at **zero violations**; CI runs `ruff check .` before tests.
- **pytest-cov** wired up (`make coverage`, term report in CI). Current backend baseline: **47.9%** over `restai`/`crons`/`modules`.
- Makefile: `make test` (via uv), `make lint`, `make code` (= `ruff check --fix`), `make format` (opt-in `ruff format`, not yet applied repo-wide to avoid a mass-reformat diff).

## Frontend test suite (Jest + Testing Library)

- Jest via `react-scripts` (CRA built-in) + Testing Library devDeps; `npm run test:ci` / `make frontend-test` runs headless with coverage; CI runs frontend tests before the frontend build.
- **50 tests across 6 suites**: `api.js` (auth headers, 422 fieldErrors parsing, 401 redirect flow, silent option), `csvExport.js` (RFC 4180 escaping, download flow), `utils.js` (formatCost sub-cent paths, hex→RGB, time deltas), `projectOptionValidators.js`, `chatErrors.js` (full status→message map incl. 429 quota-vs-rate-limit), and an `OnboardingChecklist` component test (fresh-install render, auto-hide, dismissal persistence).
- `formatChatError` extracted from `ChatPanel.jsx` to `chatErrors.js` so it's testable without the component tree (react-markdown is ESM-only and breaks under CRA's Jest transform). Production build verified.
- Coverage baseline: 2.3% overall (views untested); tested modules at 83–100%.
- Pinned `@babel/plugin-proposal-private-property-in-object` (CRA's "may break at any time" warning).

## Real bugs surfaced by the tooling (all fixed)

1. `restai/db/llms_embeddings.py` + `restai/db/projects.py` — `logging` used in error paths **without an import**: `NameError` masked the original error whenever those branches ran.
2. `restai/observability/cron_log.py` — local `import logging` inside `finish()`'s except shadowed the module import, so the earlier `removeHandler()` raised `UnboundLocalError` (silently caught): the cron log handler was **never detached**, the exact leak the code says it avoids.
3. `restai/projects/_llamaindex_loop.py` — same shadowing with `import json as _json`: tool-call args previews always fell back to `str()` instead of JSON.
4. `frontend/src/app/utils/utils.js` — `getTimeDifference` divided by **3660** instead of 3600: "2 hours ago" rendered as "1 h".
5. `restai/models/models.py` — duplicate `"currency"` key in the settings example.
6. `restai/memory/bank/compress.py` — `!= None` → `.isnot(None)`.

Mechanical cleanup: ~1,180 auto-fixes (unused imports/vars). Compat re-exports ruff removed were restored/repointed (`restai.database.verify_password`, `Agent2UnsupportedLLMError`); load-bearing package re-exports (`chat_resume/__init__`, `routers/__init__`) kept via noqa/`__all__`. Verified with a full `importlib` sweep of every `restai` module, cron entrypoint smoke-imports, and repeated full-suite runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDhwNEsAPLBswKQAVqruuV