### PR TITLE
Frontend test suite (Jest + Testing Library) with coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,13 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Install frontend dependencies
+        run: cd frontend && npm ci
+
+      - name: Frontend tests
+        run: cd frontend && npm run test:ci
+
       - name: Build frontend
         env:
           CI: false
-        run: cd frontend && npm ci && npm run build
+        run: cd frontend && npm run build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ make test             # uv run pytest tests
 pytest tests/test_projects.py -v
 pytest tests/test_projects.py::test_create_project
 make coverage         # pytest with coverage (term-missing + htmlcov/)
+make frontend-test    # Jest via react-scripts, with coverage (frontend/src/**/*.test.js*)
+cd frontend && npm test  # Jest watch mode
 
 # Code quality
 make lint             # ruff check . (zero-violation baseline — CI enforces it)
@@ -447,6 +449,8 @@ Integer Query/Form params have `ge`/`le` bounds. File uploads sanitized via `san
 **Linting**: ruff, configured in `pyproject.toml` (`[tool.ruff]`). Default E/F rules with pragmatic ignores (`E402` late imports, `E712` SQLAlchemy `== True`, `E731`, `E741`); `migrations/` and `examples/` excluded. The repo is at zero violations and CI runs `ruff check .` before tests — keep it clean. Some `__init__.py` re-exports carry `# noqa: F401` because tests/monkeypatching reach them via the package namespace; module-level "unused" imports may be compat re-exports (e.g. `restai.database.verify_password`) — check importers before deleting.
 
 **Coverage**: pytest-cov (`[tool.coverage.run]` sources: `restai`, `crons`, `modules`). `make coverage` for local HTML report; CI prints the term report.
+
+**Frontend tests**: Jest via `react-scripts test` (CRA built-in) + Testing Library; setup in `frontend/src/setupTests.js`, coverage scope in the `jest` key of `frontend/package.json` (`src/app/**`, locales excluded). `make frontend-test` / `npm run test:ci` runs headless with coverage; CI runs it before the frontend build. Tests colocate with source (`*.test.js`/`*.test.jsx`). Pure-logic modules (utils, validators, `chatErrors.js`) are the pattern to follow — components importing `react-markdown` (ESM-only) break under CRA's Jest transform, so extract logic out of such components rather than rendering them (that's why `formatChatError` lives in `chatErrors.js`, not ChatPanel).
 
 ## Key env vars
 

--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,10 @@ version:
 test:
 	uv run --no-group gpu pytest tests
 
+.PHONY: frontend-test
+frontend-test:
+	cd frontend && npm run test:ci
+
 .PHONY: coverage
 coverage:
 	uv run --no-group gpu pytest tests --ignore=tests/test_projects.py --cov --cov-report=term-missing:skip-covered --cov-report=html

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -59,6 +59,9 @@
         "vis-network": "^9.1.13"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^14.3.1",
+        "@testing-library/user-event": "^14.6.1",
         "axios-mock-adapter": "^2.1.0",
         "cross-env": "^10.1.0",
         "customize-cra": "^1.0.0",
@@ -72,6 +75,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -4680,6 +4690,193 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.3.1.tgz",
+      "integrity": "sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^9.0.0",
+        "@types/react-dom": "^18.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@testing-library/react/node_modules/@testing-library/dom": {
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
+      "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.1.3",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@testing-library/react/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/react/node_modules/aria-query": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "deep-equal": "^2.0.5"
+      }
+    },
+    "node_modules/@testing-library/react/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/react/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@testing-library/react/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/react/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -4687,6 +4884,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5055,6 +5259,16 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -8041,6 +8255,13 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssdb": {
       "version": "7.11.0",
       "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.11.0.tgz",
@@ -8482,6 +8703,39 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA=="
     },
+    "node_modules/deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -8696,6 +8950,13 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -9033,6 +9294,27 @@
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-iterator-helpers": {
@@ -11613,6 +11895,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -11639,13 +11931,14 @@
       "license": "MIT"
     },
     "node_modules/internal-slot": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
-      "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "hasown": "^2.0.0",
-        "side-channel": "^1.0.4"
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11690,6 +11983,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-array-buffer": {
@@ -14796,6 +15106,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -15940,6 +16260,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mini-css-extract-plugin": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.8.0.tgz",
@@ -16339,6 +16669,23 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -19296,6 +19643,20 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -20456,6 +20817,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -20664,6 +21039,19 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -59,6 +59,7 @@
         "vis-network": "^9.1.13"
       },
       "devDependencies": {
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^14.3.1",
         "@testing-library/user-event": "^14.6.1",
@@ -677,9 +678,18 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       },
@@ -1908,6 +1918,18 @@
         "core-js-compat": "^3.31.0",
         "semver": "^6.3.1"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,12 +7,19 @@
     "start": "REACT_APP_VERSION=$npm_package_version react-scripts start",
     "build": "REACT_APP_VERSION=$npm_package_version react-scripts build",
     "test": "react-scripts test",
+    "test:ci": "cross-env CI=true react-scripts test --coverage --watchAll=false",
     "eject": "react-scripts eject",
     "ghp": "react-scripts build && gh-pages -d build"
   },
   "eslintConfig": {
     "extends": [
       "react-app"
+    ]
+  },
+  "jest": {
+    "collectCoverageFrom": [
+      "src/app/**/*.{js,jsx}",
+      "!src/app/locales/**"
     ]
   },
   "browserslist": {
@@ -79,6 +86,9 @@
     "vis-network": "^9.1.13"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^14.3.1",
+    "@testing-library/user-event": "^14.6.1",
     "axios-mock-adapter": "^2.1.0",
     "cross-env": "^10.1.0",
     "customize-cra": "^1.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -86,6 +86,7 @@
     "vis-network": "^9.1.13"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^14.3.1",
     "@testing-library/user-event": "^14.6.1",

--- a/frontend/src/app/components/Breadcrumb.test.jsx
+++ b/frontend/src/app/components/Breadcrumb.test.jsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import Breadcrumb from "./Breadcrumb";
+
+const renderCrumbs = (routeSegments) =>
+  render(
+    <MemoryRouter>
+      <Breadcrumb routeSegments={routeSegments} />
+    </MemoryRouter>
+  );
+
+describe("Breadcrumb", () => {
+  it("links intermediate segments and renders the last as plain text", () => {
+    renderCrumbs([
+      { name: "Projects", path: "/projects" },
+      { name: "My Project", path: "/projects/1" },
+    ]);
+
+    const link = screen.getByRole("link", { name: "Projects" });
+    expect(link).toHaveAttribute("href", "/projects");
+
+    // Final segment: shown (twice — heading + trail) but never a link.
+    expect(screen.getAllByText("My Project").length).toBeGreaterThan(0);
+    expect(screen.queryByRole("link", { name: "My Project" })).not.toBeInTheDocument();
+  });
+
+  it("renders only the home icon when no segments are given", () => {
+    renderCrumbs(undefined);
+    expect(screen.getAllByRole("link")).toHaveLength(1);
+  });
+});

--- a/frontend/src/app/components/ErrorBoundary.test.jsx
+++ b/frontend/src/app/components/ErrorBoundary.test.jsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ErrorBoundary from "./ErrorBoundary";
+
+function Bomb() {
+  throw new Error("boom");
+}
+
+describe("ErrorBoundary", () => {
+  it("renders children when nothing throws", () => {
+    render(
+      <ErrorBoundary>
+        <div>all good</div>
+      </ErrorBoundary>
+    );
+    expect(screen.getByText("all good")).toBeInTheDocument();
+  });
+
+  it("catches render errors and shows the fallback with a refresh button", async () => {
+    // React logs caught errors loudly — silence for this intentional throw.
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const original = window.location;
+    delete window.location;
+    window.location = { ...original, reload: jest.fn() };
+    try {
+      render(
+        <ErrorBoundary>
+          <Bomb />
+        </ErrorBoundary>
+      );
+      expect(screen.getByText("Something went wrong.")).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole("button", { name: /refresh/i }));
+      expect(window.location.reload).toHaveBeenCalled();
+    } finally {
+      window.location = original;
+      spy.mockRestore();
+    }
+  });
+});

--- a/frontend/src/app/components/ProjectTypeChip.test.jsx
+++ b/frontend/src/app/components/ProjectTypeChip.test.jsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import ProjectTypeChip from "./ProjectTypeChip";
+import { PROJECT_TYPE_COLORS } from "app/utils/constant";
+
+describe("ProjectTypeChip", () => {
+  it.each(["rag", "agent", "block"])("renders the %s type with its palette color", (type) => {
+    render(<ProjectTypeChip type={type} />);
+    const chip = screen.getByText(type);
+    expect(chip).toBeInTheDocument();
+    expect(chip.closest(".MuiChip-root")).toHaveStyle({
+      color: PROJECT_TYPE_COLORS[type].color,
+    });
+  });
+
+  it("falls back to the default style for unknown types", () => {
+    render(<ProjectTypeChip type="mystery" />);
+    const chip = screen.getByText("mystery");
+    expect(chip.closest(".MuiChip-root")).toHaveStyle({ color: "#ef4444" });
+  });
+
+  it("forwards extra props to the underlying Chip", () => {
+    render(<ProjectTypeChip type="rag" data-testid="chip" />);
+    expect(screen.getByTestId("chip")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/contexts/JWTAuthContext.test.jsx
+++ b/frontend/src/app/contexts/JWTAuthContext.test.jsx
@@ -1,0 +1,202 @@
+import { useContext } from "react";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import axios from "axios";
+import AuthContext, { AuthProvider } from "./JWTAuthContext";
+import { applyLanguage } from "app/i18n";
+
+jest.mock("axios", () => ({ get: jest.fn(), post: jest.fn() }));
+// app/components/index.js re-exports the whole layout tree — stub the one
+// piece the provider renders while initializing.
+jest.mock("app/components", () => ({ MatxLoading: () => <div data-testid="loading" /> }));
+jest.mock("app/i18n", () => ({ applyLanguage: jest.fn() }));
+
+// Probe that surfaces state and exposes the context actions to tests.
+let ctx;
+function Probe() {
+  ctx = useContext(AuthContext);
+  return (
+    <div>
+      <span data-testid="authed">{String(ctx.isAuthenticated)}</span>
+      <span data-testid="role">{ctx.user?.role || "none"}</span>
+      <span data-testid="impersonating">{String(ctx.isImpersonating)}</span>
+    </div>
+  );
+}
+
+const renderProvider = () =>
+  render(
+    <AuthProvider>
+      <Probe />
+    </AuthProvider>
+  );
+
+const whoamiUser = (over = {}) => ({
+  username: "u1",
+  is_admin: false,
+  teams: [],
+  admin_teams: [],
+  ...over,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  ctx = undefined;
+  sessionStorage.clear();
+});
+
+describe("AuthProvider bootstrap", () => {
+  it("shows the loader, then INITs authenticated from whoami with role assignment", async () => {
+    axios.get.mockResolvedValue({ data: whoamiUser({ is_admin: true }) });
+    renderProvider();
+    expect(screen.getByTestId("loading")).toBeInTheDocument();
+
+    expect(await screen.findByTestId("authed")).toHaveTextContent("true");
+    expect(screen.getByTestId("role")).toHaveTextContent("ADMIN");
+  });
+
+  it("assigns TEAM_ADMIN when the user admins any team, USER otherwise", async () => {
+    axios.get.mockResolvedValue({ data: whoamiUser({ admin_teams: [{ id: 1 }] }) });
+    renderProvider();
+    expect(await screen.findByTestId("role")).toHaveTextContent("TEAM_ADMIN");
+  });
+
+  it("INITs unauthenticated when whoami fails", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    axios.get.mockRejectedValue(new Error("401"));
+    renderProvider();
+    expect(await screen.findByTestId("authed")).toHaveTextContent("false");
+    expect(screen.getByTestId("role")).toHaveTextContent("none");
+    console.error.mockRestore();
+  });
+
+  it("applies the user's saved language, including legacy JSON-string options", async () => {
+    axios.get.mockResolvedValue({
+      data: whoamiUser({ options: JSON.stringify({ language: "pt" }) }),
+    });
+    renderProvider();
+    await screen.findByTestId("authed");
+    expect(applyLanguage).toHaveBeenCalledWith("pt");
+  });
+
+  it("flags impersonation reported by whoami", async () => {
+    axios.get.mockResolvedValue({ data: whoamiUser({ impersonating: true }) });
+    renderProvider();
+    expect(await screen.findByTestId("impersonating")).toHaveTextContent("true");
+  });
+});
+
+describe("login", () => {
+  beforeEach(() => {
+    // Bootstrap unauthenticated so login drives the transition.
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    axios.get.mockRejectedValueOnce(new Error("401"));
+  });
+  afterEach(() => console.error.mockRestore());
+
+  it("logs in with Basic credentials and INITs from whoami", async () => {
+    renderProvider();
+    await screen.findByTestId("authed");
+
+    axios.post.mockResolvedValue({ data: {} });
+    axios.get.mockResolvedValue({ data: whoamiUser() });
+
+    let result;
+    await act(async () => {
+      result = await ctx.login("u1", "pw");
+    });
+    expect(result).toEqual({ requires_totp: false });
+    expect(axios.post).toHaveBeenCalledWith(
+      "/auth/login",
+      {},
+      { auth: { username: "u1", password: "pw" } }
+    );
+    expect(screen.getByTestId("authed")).toHaveTextContent("true");
+    expect(screen.getByTestId("role")).toHaveTextContent("USER");
+  });
+
+  it("short-circuits with the TOTP token when 2FA is required", async () => {
+    renderProvider();
+    await screen.findByTestId("authed");
+
+    axios.post.mockResolvedValue({ data: { requires_totp: true, totp_token: "tt" } });
+    let result;
+    await act(async () => {
+      result = await ctx.login("u1", "pw");
+    });
+    expect(result).toEqual({ requires_totp: true, totp_token: "tt" });
+    expect(screen.getByTestId("authed")).toHaveTextContent("false");
+  });
+
+  it("stashes the password-age warning for the post-login banner", async () => {
+    renderProvider();
+    await screen.findByTestId("authed");
+
+    axios.post.mockResolvedValue({ data: { password_warning: { days: 99 } } });
+    axios.get.mockResolvedValue({ data: whoamiUser() });
+    await act(async () => {
+      await ctx.login("u1", "pw");
+    });
+    expect(JSON.parse(sessionStorage.getItem("password_warning"))).toEqual({ days: 99 });
+  });
+
+  it("surfaces the server detail on failure", async () => {
+    renderProvider();
+    await screen.findByTestId("authed");
+
+    axios.post.mockRejectedValue({ response: { data: { detail: "Bad credentials" } } });
+    await expect(ctx.login("u1", "nope")).rejects.toThrow("Bad credentials");
+    expect(screen.getByTestId("authed")).toHaveTextContent("false");
+  });
+});
+
+describe("verifyTotp / logout", () => {
+  beforeEach(() => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    axios.get.mockRejectedValueOnce(new Error("401"));
+  });
+  afterEach(() => console.error.mockRestore());
+
+  it("verifyTotp posts the code and INITs from whoami", async () => {
+    renderProvider();
+    await screen.findByTestId("authed");
+
+    axios.post.mockResolvedValue({ data: {} });
+    axios.get.mockResolvedValue({ data: whoamiUser({ is_admin: true }) });
+    await act(async () => {
+      await ctx.verifyTotp("tt", "123456");
+    });
+    expect(axios.post).toHaveBeenCalledWith(
+      "/auth/verify-totp",
+      { token: "tt", code: "123456" },
+      { withCredentials: true }
+    );
+    expect(screen.getByTestId("role")).toHaveTextContent("ADMIN");
+  });
+
+  it("verifyTotp rethrows the server detail on bad codes", async () => {
+    renderProvider();
+    await screen.findByTestId("authed");
+
+    axios.post.mockRejectedValue({ response: { data: { detail: "Invalid code." } } });
+    await expect(ctx.verifyTotp("tt", "000000")).rejects.toThrow("Invalid code.");
+  });
+
+  it("logout clears state and posts to the backend", async () => {
+    renderProvider();
+    await screen.findByTestId("authed");
+
+    axios.post.mockResolvedValue({ data: {} });
+    axios.get.mockResolvedValue({ data: whoamiUser() });
+    await act(async () => {
+      await ctx.login("u1", "pw");
+    });
+    expect(screen.getByTestId("authed")).toHaveTextContent("true");
+
+    await act(async () => {
+      ctx.logout();
+    });
+    expect(screen.getByTestId("authed")).toHaveTextContent("false");
+    expect(axios.post).toHaveBeenCalledWith("/auth/logout", {}, { withCredentials: true });
+  });
+});

--- a/frontend/src/app/contexts/PlatformContext.test.jsx
+++ b/frontend/src/app/contexts/PlatformContext.test.jsx
@@ -1,0 +1,76 @@
+import { render, screen, waitFor, act } from "@testing-library/react";
+import PlatformProvider, { usePlatformCapabilities } from "./PlatformContext";
+
+let ctx;
+function Probe() {
+  ctx = usePlatformCapabilities();
+  return (
+    <div>
+      <span data-testid="loading">{String(ctx.isLoading)}</span>
+      <span data-testid="app">{ctx.platformCapabilities.app_name}</span>
+      <span data-testid="gpu">{String(ctx.platformCapabilities.gpu)}</span>
+    </div>
+  );
+}
+
+const renderPlatform = () =>
+  render(
+    <PlatformProvider>
+      <Probe />
+    </PlatformProvider>
+  );
+
+beforeEach(() => {
+  ctx = undefined;
+  global.fetch = jest.fn();
+});
+
+afterAll(() => {
+  delete global.fetch;
+});
+
+describe("PlatformProvider", () => {
+  it("loads capabilities from /setup and clears the loading flag", async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ gpu: true, app_name: "Acme AI", sso: ["google"] }),
+    });
+    renderPlatform();
+    expect(screen.getByTestId("loading")).toHaveTextContent("true");
+
+    await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("false"));
+    expect(screen.getByTestId("app")).toHaveTextContent("Acme AI");
+    expect(screen.getByTestId("gpu")).toHaveTextContent("true");
+    expect(global.fetch).toHaveBeenCalledWith("/setup");
+    expect(ctx.platformCapabilities.sso).toEqual(["google"]);
+    // Absent fields fall back to safe defaults.
+    expect(ctx.platformCapabilities.payments_enabled).toBe(false);
+  });
+
+  it("keeps defaults and stops loading when /setup fails", async () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    global.fetch.mockRejectedValue(new Error("network down"));
+    renderPlatform();
+    await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("false"));
+    expect(screen.getByTestId("app")).toHaveTextContent("RESTai");
+    spy.mockRestore();
+  });
+
+  it("refreshCapabilities re-fetches on demand", async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ app_name: "First" }),
+    });
+    renderPlatform();
+    await waitFor(() => expect(screen.getByTestId("app")).toHaveTextContent("First"));
+
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ app_name: "Second" }),
+    });
+    await act(async () => {
+      await ctx.refreshCapabilities();
+    });
+    expect(screen.getByTestId("app")).toHaveTextContent("Second");
+  });
+});

--- a/frontend/src/app/contexts/SettingsContext.test.jsx
+++ b/frontend/src/app/contexts/SettingsContext.test.jsx
@@ -1,0 +1,45 @@
+import { useContext } from "react";
+import { render, screen, act } from "@testing-library/react";
+import SettingsProvider, { SettingsContext } from "./SettingsContext";
+import { MatxLayoutSettings } from "app/components/MatxLayout/settings";
+
+let ctx;
+function Probe() {
+  ctx = useContext(SettingsContext);
+  return <span data-testid="mode">{ctx.settings.layout1Settings ? "loaded" : "empty"}</span>;
+}
+
+describe("SettingsProvider", () => {
+  it("defaults to MatxLayoutSettings", () => {
+    render(
+      <SettingsProvider>
+        <Probe />
+      </SettingsProvider>
+    );
+    expect(ctx.settings).toEqual(MatxLayoutSettings);
+  });
+
+  it("accepts an initial settings override", () => {
+    const custom = { ...MatxLayoutSettings, activeLayout: "layout2" };
+    render(
+      <SettingsProvider settings={custom}>
+        <Probe />
+      </SettingsProvider>
+    );
+    expect(ctx.settings.activeLayout).toBe("layout2");
+  });
+
+  it("deep-merges updates instead of replacing wholesale", () => {
+    render(
+      <SettingsProvider>
+        <Probe />
+      </SettingsProvider>
+    );
+    const before = ctx.settings;
+    act(() => ctx.updateSettings({ layout1Settings: { leftSidebar: { show: false } } }));
+    // Updated leaf applied…
+    expect(ctx.settings.layout1Settings.leftSidebar.show).toBe(false);
+    // …while unrelated keys survive the merge.
+    expect(ctx.settings.activeLayout).toBe(before.activeLayout);
+  });
+});

--- a/frontend/src/app/contexts/TeamBrandingContext.test.jsx
+++ b/frontend/src/app/contexts/TeamBrandingContext.test.jsx
@@ -1,0 +1,113 @@
+import { render, screen, act } from "@testing-library/react";
+import { TeamBrandingProvider, useTeamBranding } from "./TeamBrandingContext";
+import api from "app/utils/api";
+import useAuth from "app/hooks/useAuth";
+
+jest.mock("app/utils/api", () => ({ patch: jest.fn() }));
+jest.mock("app/hooks/useAuth", () => jest.fn());
+
+let ctx;
+function Probe() {
+  ctx = useTeamBranding();
+  return (
+    <div>
+      <span data-testid="team">{ctx.teamName || "none"}</span>
+      <span data-testid="app">{ctx.branding?.app_name || "none"}</span>
+      <span data-testid="count">{ctx.brandedTeams.length}</span>
+    </div>
+  );
+}
+
+const renderBranding = () =>
+  render(
+    <TeamBrandingProvider>
+      <Probe />
+    </TeamBrandingProvider>
+  );
+
+const branded = (id, name, app_name) => ({ id, name, branding: { app_name } });
+const plain = (id, name) => ({ id, name, branding: null });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  api.patch.mockResolvedValue({});
+  ctx = undefined;
+});
+
+describe("TeamBrandingProvider", () => {
+  it("exposes nulls when unauthenticated", () => {
+    useAuth.mockReturnValue({ user: null, isAuthenticated: false });
+    renderBranding();
+    expect(screen.getByTestId("team")).toHaveTextContent("none");
+    expect(screen.getByTestId("count")).toHaveTextContent("0");
+  });
+
+  it("picks the first branded team when there is no preference", () => {
+    useAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { username: "u", teams: [plain(1, "A"), branded(2, "B", "B-App")], admin_teams: [] },
+    });
+    renderBranding();
+    expect(screen.getByTestId("team")).toHaveTextContent("B");
+    expect(screen.getByTestId("app")).toHaveTextContent("B-App");
+    expect(screen.getByTestId("count")).toHaveTextContent("1");
+  });
+
+  it("honors the user's preferred_team_id over the first branded team", () => {
+    useAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: {
+        username: "u",
+        options: { preferred_team_id: 3 },
+        teams: [branded(2, "B", "B-App"), branded(3, "C", "C-App")],
+        admin_teams: [],
+      },
+    });
+    renderBranding();
+    expect(screen.getByTestId("team")).toHaveTextContent("C");
+  });
+
+  it("dedupes teams the user both belongs to and admins", () => {
+    const t = branded(5, "Dup", "Dup-App");
+    useAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { username: "u", teams: [t], admin_teams: [t] },
+    });
+    renderBranding();
+    expect(screen.getByTestId("count")).toHaveTextContent("1");
+  });
+
+  it("reports no branding when no team has any configured", () => {
+    useAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { username: "u", teams: [plain(1, "A")], admin_teams: [] },
+    });
+    renderBranding();
+    expect(screen.getByTestId("team")).toHaveTextContent("none");
+    expect(screen.getByTestId("app")).toHaveTextContent("none");
+  });
+
+  it("setActiveTeamId switches the branding and persists the preference", async () => {
+    useAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: {
+        username: "u",
+        token: "tok",
+        teams: [branded(2, "B", "B-App"), branded(3, "C", "C-App")],
+        admin_teams: [],
+      },
+    });
+    renderBranding();
+    expect(screen.getByTestId("team")).toHaveTextContent("B");
+
+    await act(async () => {
+      ctx.setActiveTeamId(3);
+    });
+    expect(screen.getByTestId("team")).toHaveTextContent("C");
+    expect(api.patch).toHaveBeenCalledWith(
+      "/users/u",
+      { options: { preferred_team_id: 3 } },
+      "tok"
+    );
+  });
+});

--- a/frontend/src/app/utils/api.test.js
+++ b/frontend/src/app/utils/api.test.js
@@ -1,0 +1,133 @@
+import api, { ApiError } from "./api";
+import { toast } from "react-toastify";
+
+jest.mock("react-toastify", () => ({
+  toast: { error: jest.fn() },
+}));
+
+const jsonResponse = (status, body) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  statusText: `HTTP ${status}`,
+  json: () => Promise.resolve(body),
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.fetch = jest.fn();
+  sessionStorage.clear();
+});
+
+afterAll(() => {
+  delete global.fetch;
+});
+
+describe("api client", () => {
+  it("GET returns parsed JSON and sends Basic auth from the token", async () => {
+    global.fetch.mockResolvedValue(jsonResponse(200, { hello: "world" }));
+    const out = await api.get("/users", "dG9rZW4=");
+    expect(out).toEqual({ hello: "world" });
+    const [url, opts] = global.fetch.mock.calls[0];
+    expect(url).toBe("/users");
+    expect(opts.headers.get("Authorization")).toBe("Basic dG9rZW4=");
+  });
+
+  it("POST serializes the body and sets JSON content type", async () => {
+    global.fetch.mockResolvedValue(jsonResponse(200, {}));
+    await api.post("/projects", { name: "p1" }, null);
+    const [, opts] = global.fetch.mock.calls[0];
+    expect(opts.method).toBe("POST");
+    expect(opts.body).toBe(JSON.stringify({ name: "p1" }));
+    expect(opts.headers.get("Content-Type")).toBe("application/json");
+  });
+
+  it("POST passes FormData through untouched (no forced content type)", async () => {
+    global.fetch.mockResolvedValue(jsonResponse(200, {}));
+    const fd = new FormData();
+    fd.append("file", new Blob(["x"]), "x.txt");
+    await api.post("/upload", fd, null);
+    const [, opts] = global.fetch.mock.calls[0];
+    expect(opts.body).toBe(fd);
+    expect(opts.headers.get("Content-Type")).toBeNull();
+  });
+
+  it("returns null on 204 No Content", async () => {
+    global.fetch.mockResolvedValue({ ok: true, status: 204, json: () => Promise.reject() });
+    await expect(api.delete("/projects/1", null)).resolves.toBeNull();
+  });
+
+  it("throws ApiError with detail and toasts on plain failures", async () => {
+    global.fetch.mockResolvedValue(jsonResponse(403, { detail: "Forbidden thing" }));
+    await expect(api.get("/x", null)).rejects.toMatchObject({
+      status: 403,
+      detail: "Forbidden thing",
+    });
+    expect(toast.error).toHaveBeenCalledWith("Forbidden thing");
+  });
+
+  it("suppresses the toast with the silent option", async () => {
+    global.fetch.mockResolvedValue(jsonResponse(403, { detail: "quiet" }));
+    await expect(api.get("/x", null, { silent: true })).rejects.toBeInstanceOf(ApiError);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("parses FastAPI 422 arrays into fieldErrors and a joined message", async () => {
+    const detail = [
+      { loc: ["body", "options", "rate_limit"], msg: "Value error, too big" },
+      { loc: ["body", "name"], msg: "field required" },
+      { loc: ["header", "x"], msg: "ignored scope" },
+      { loc: ["body"], msg: "too-short loc ignored" },
+    ];
+    global.fetch.mockResolvedValue(jsonResponse(422, { detail }));
+    let err;
+    try {
+      await api.post("/projects", {}, null);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(422);
+    // "Value error, " prefix stripped; nested body loc flattened with dots
+    expect(err.fieldErrors).toEqual({
+      "options.rate_limit": "too big",
+      name: "field required",
+    });
+    expect(err.detail).toContain("field required");
+  });
+
+  it("extracts the msg from legacy stringified-dict details", async () => {
+    global.fetch.mockResolvedValue(
+      jsonResponse(400, { detail: "{'type': 'x', 'msg': 'Legacy message here'}" })
+    );
+    await expect(api.get("/x", null)).rejects.toMatchObject({ detail: "Legacy message here" });
+  });
+
+  it("redirects to login and flags the session on 401 outside /login", async () => {
+    const original = window.location;
+    delete window.location;
+    window.location = { pathname: "/admin/projects", href: "" };
+    try {
+      global.fetch.mockResolvedValue(jsonResponse(401, { detail: "nope" }));
+      await expect(api.get("/x", null)).rejects.toMatchObject({ detail: "Session expired" });
+      expect(sessionStorage.getItem("session_expired")).toBe("1");
+      expect(window.location.href).toBe("/admin/login");
+      expect(toast.error).not.toHaveBeenCalled();
+    } finally {
+      window.location = original;
+    }
+  });
+
+  it("does NOT redirect on 401 when already on the login page", async () => {
+    const original = window.location;
+    delete window.location;
+    window.location = { pathname: "/admin/login", href: "" };
+    try {
+      global.fetch.mockResolvedValue(jsonResponse(401, { detail: "bad creds" }));
+      await expect(api.get("/x", null)).rejects.toMatchObject({ status: 401, detail: "bad creds" });
+      expect(window.location.href).toBe("");
+      expect(toast.error).toHaveBeenCalledWith("bad creds");
+    } finally {
+      window.location = original;
+    }
+  });
+});

--- a/frontend/src/app/utils/csvExport.test.js
+++ b/frontend/src/app/utils/csvExport.test.js
@@ -1,0 +1,69 @@
+import { toCsv, downloadCsv } from "./csvExport";
+
+describe("toCsv", () => {
+  const rows = [
+    { name: "alpha", count: 3 },
+    { name: "beta", count: 7 },
+  ];
+
+  it("builds a header line plus one line per row, CRLF-joined", () => {
+    const csv = toCsv(rows, [{ key: "name" }, { key: "count" }]);
+    expect(csv).toBe("name,count\r\nalpha,3\r\nbeta,7");
+  });
+
+  it("uses header labels when given, falling back to key", () => {
+    const csv = toCsv([], [{ key: "a", header: "Column A" }, { key: "b" }]);
+    expect(csv).toBe("Column A,b");
+  });
+
+  it("prefers the get() accessor over row[key]", () => {
+    const csv = toCsv(rows, [{ key: "name", get: (r) => r.name.toUpperCase() }]);
+    expect(csv).toBe("name\r\nALPHA\r\nBETA");
+  });
+
+  it("escapes commas, quotes and newlines per RFC 4180", () => {
+    const tricky = [{ v: 'say "hi", ok?\nnew line' }];
+    const csv = toCsv(tricky, [{ key: "v" }]);
+    expect(csv).toBe('v\r\n"say ""hi"", ok?\nnew line"');
+  });
+
+  it("renders null/undefined as empty and objects as JSON", () => {
+    const csv = toCsv([{ a: null, b: { x: 1 } }], [{ key: "a" }, { key: "b" }]);
+    expect(csv).toBe('a,b\r\n,"{""x"":1}"');
+  });
+});
+
+describe("downloadCsv", () => {
+  afterEach(() => jest.useRealTimers());
+
+  it("creates a temporary anchor with a .csv filename and clicks it", () => {
+    jest.useFakeTimers();
+    const clicks = [];
+    const origCreateObjectURL = URL.createObjectURL;
+    const origRevokeObjectURL = URL.revokeObjectURL;
+    URL.createObjectURL = jest.fn(() => "blob:fake");
+    URL.revokeObjectURL = jest.fn();
+    const clickSpy = jest
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(function () {
+        clicks.push({ href: this.href, download: this.download });
+      });
+
+    try {
+      downloadCsv("report", "a,b\r\n1,2");
+      expect(clicks).toHaveLength(1);
+      expect(clicks[0].download).toBe("report.csv");
+
+      downloadCsv("already.csv", "x");
+      expect(clicks[1].download).toBe("already.csv");
+
+      // Flush the deferred revokeObjectURL while the mock is still installed.
+      jest.runOnlyPendingTimers();
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:fake");
+    } finally {
+      clickSpy.mockRestore();
+      URL.createObjectURL = origCreateObjectURL;
+      URL.revokeObjectURL = origRevokeObjectURL;
+    }
+  });
+});

--- a/frontend/src/app/utils/utils.js
+++ b/frontend/src/app/utils/utils.js
@@ -112,7 +112,7 @@ export function getTimeDifference(date) {
 
   if (difference < 60) return `${Math.floor(difference)} sec`;
   else if (difference < 3600) return `${Math.floor(difference / 60)} min`;
-  else if (difference < 86400) return `${Math.floor(difference / 3660)} h`;
+  else if (difference < 86400) return `${Math.floor(difference / 3600)} h`;
   else if (difference < 86400 * 30) return `${Math.floor(difference / 86400)} d`;
   else if (difference < 86400 * 30 * 12) return `${Math.floor(difference / 86400 / 30)} mon`;
   else return `${(difference / 86400 / 30 / 12).toFixed(1)} y`;

--- a/frontend/src/app/utils/utils.test.js
+++ b/frontend/src/app/utils/utils.test.js
@@ -1,0 +1,72 @@
+import { formatCost, convertHexToRGB, getTimeDifference } from "./utils";
+
+describe("formatCost", () => {
+  it("renders zero as $0.00", () => {
+    expect(formatCost(0)).toBe("$0.00");
+    expect(formatCost(null)).toBe("$0.00");
+    expect(formatCost(undefined)).toBe("$0.00");
+    expect(formatCost("")).toBe("$0.00");
+  });
+
+  it("renders regular amounts with two decimals", () => {
+    expect(formatCost(1)).toBe("$1.00");
+    expect(formatCost(0.5)).toBe("$0.50");
+    expect(formatCost(12.345)).toBe("$12.35");
+  });
+
+  it("adds thousands separators", () => {
+    expect(formatCost(1234.5)).toBe("$1,234.50");
+  });
+
+  it("surfaces sub-cent amounts instead of rounding to $0.00", () => {
+    expect(formatCost(0.005)).toBe("$0.0050");
+    expect(formatCost(0.000005)).toBe("$0.0000050");
+    // never shows a real charge as all zeros
+    expect(formatCost(0.000005)).not.toMatch(/^\$0\.0+$/);
+  });
+
+  it("caps sub-cent precision at 10 decimals", () => {
+    const out = formatCost(1e-12);
+    const decimals = out.split(".")[1];
+    expect(decimals.length).toBeLessThanOrEqual(10);
+  });
+
+  it("uses the absolute value for negative amounts", () => {
+    expect(formatCost(-2)).toBe("$2.00");
+  });
+});
+
+describe("convertHexToRGB", () => {
+  it("converts 6-digit hex", () => {
+    expect(convertHexToRGB("#ff0000")).toBe("255,0,0");
+    expect(convertHexToRGB("#00ff7f")).toBe("0,255,127");
+  });
+
+  it("converts 3-digit shorthand hex", () => {
+    expect(convertHexToRGB("#fff")).toBe("255,255,255");
+    expect(convertHexToRGB("#f00")).toBe("255,0,0");
+  });
+
+  it("extracts the triplet from an rgba() string", () => {
+    expect(convertHexToRGB("rgba(10, 20, 30, 0.5)")).toBe("10, 20, 30");
+  });
+
+  it("returns undefined for invalid input", () => {
+    expect(convertHexToRGB("not-a-color")).toBeUndefined();
+  });
+});
+
+describe("getTimeDifference", () => {
+  afterEach(() => jest.useRealTimers());
+
+  const at = (secondsAgo) => new Date(Date.now() - secondsAgo * 1000);
+
+  it("formats seconds, minutes, days and months", () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-08-01T12:00:00Z"));
+    expect(getTimeDifference(at(30))).toBe("30 sec");
+    expect(getTimeDifference(at(120))).toBe("2 min");
+    expect(getTimeDifference(at(7200))).toBe("2 h");
+    expect(getTimeDifference(at(86400 * 3))).toBe("3 d");
+    expect(getTimeDifference(at(86400 * 60))).toBe("2 mon");
+  });
+});

--- a/frontend/src/app/views/dashboard/shared/OnboardingChecklist.test.jsx
+++ b/frontend/src/app/views/dashboard/shared/OnboardingChecklist.test.jsx
@@ -1,0 +1,83 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import OnboardingChecklist from "./OnboardingChecklist";
+import api from "app/utils/api";
+
+jest.mock("app/utils/api", () => ({ get: jest.fn() }));
+jest.mock("app/hooks/useAuth", () => jest.fn());
+import useAuth from "app/hooks/useAuth";
+
+const DISMISS_KEY = "restai_onboarding_dismissed";
+
+// Route api.get by path so each test controls the platform state.
+function mockPlatform({ llms = [], projects = [], teams = [] }) {
+  api.get.mockImplementation((path) => {
+    if (path === "/llms") return Promise.resolve(llms);
+    if (path === "/projects") return Promise.resolve({ projects });
+    if (path === "/teams") return Promise.resolve({ teams });
+    return Promise.reject(new Error(`unexpected path ${path}`));
+  });
+}
+
+const renderChecklist = () =>
+  render(
+    <MemoryRouter>
+      <OnboardingChecklist />
+    </MemoryRouter>
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  localStorage.clear();
+  useAuth.mockReturnValue({ user: { is_admin: true, token: "tok" } });
+});
+
+describe("OnboardingChecklist", () => {
+  it("shows the three steps on a fresh install", async () => {
+    mockPlatform({});
+    renderChecklist();
+    expect(await screen.findByText("Add an LLM")).toBeInTheDocument();
+    expect(screen.getByText("Add the LLM to a team")).toBeInTheDocument();
+    expect(screen.getByText("Create your first project")).toBeInTheDocument();
+  });
+
+  it("renders nothing for non-admin users", () => {
+    useAuth.mockReturnValue({ user: { is_admin: false, token: "tok" } });
+    mockPlatform({});
+    const { container } = renderChecklist();
+    expect(container).toBeEmptyDOMElement();
+    expect(api.get).not.toHaveBeenCalled();
+  });
+
+  it("auto-hides when every step is complete", async () => {
+    mockPlatform({
+      llms: [{ name: "gpt" }],
+      projects: [{ id: 1 }],
+      teams: [{ id: 1, llms: ["gpt"] }],
+    });
+    const { container } = renderChecklist();
+    // Wait for the three fetches to settle, then assert it stayed empty.
+    await waitFor(() => expect(api.get).toHaveBeenCalledTimes(3));
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+  });
+
+  it("stays hidden once dismissed and persists the dismissal", async () => {
+    mockPlatform({});
+    renderChecklist();
+    await screen.findByText("Add an LLM");
+
+    const dismiss = screen.getByLabelText(/dismiss/i);
+    await userEvent.click(dismiss);
+
+    expect(localStorage.getItem(DISMISS_KEY)).toBe("1");
+    expect(screen.queryByText("Add an LLM")).not.toBeInTheDocument();
+  });
+
+  it("respects a pre-existing dismissal", () => {
+    localStorage.setItem(DISMISS_KEY, "1");
+    mockPlatform({});
+    const { container } = renderChecklist();
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/app/views/projects/components/ChatPanel.jsx
+++ b/frontend/src/app/views/projects/components/ChatPanel.jsx
@@ -10,36 +10,11 @@ import useAuth from "app/hooks/useAuth";
 import api from "app/utils/api";
 import MessageBubble from "./MessageBubble";
 import PlaygroundLanes from "./PlaygroundLanes";
+import { formatChatError } from "./chatErrors";
 
 const HiddenInput = styled("input")({ display: "none" });
 
 const url = process.env.REACT_APP_RESTAI_API_URL || "";
-
-// Called from both streaming and non-streaming error paths so messaging is
-// consistent regardless of transport.
-function formatChatError(t, status, detail) {
-  const d = (detail || "").toString().trim();
-  switch (status) {
-    case 401: return t("chat.error.sessionExpired");
-    case 402: return t("chat.error.budgetExhausted");
-    case 403: return d || t("chat.error.forbidden");
-    case 404: return t("chat.error.notFound");
-    case 413: return t("chat.error.tooLarge");
-    case 422: return d ? t("chat.error.invalidDetail", { detail: d }) : t("chat.error.invalid");
-    case 429:
-      if (d && d.toLowerCase().includes("quota"))
-        return t("chat.error.quotaReached", { detail: d });
-      return t("chat.error.rateLimit");
-    case 500: return t("chat.error.internal");
-    case 502:
-    case 503:
-      return t("chat.error.overloaded");
-    case 504: return t("chat.error.timeout");
-    default:
-      if (d) return t("chat.error.default", { detail: d });
-      return t("chat.error.generic");
-  }
-}
 
 export default function ChatPanel({ project, systemOverride, sharedQuestion, onQuestionSent, compact = false, streaming = false, context = null, autoScroll = true, laneLayout = false, hideInput = false }) {
   const { t } = useTranslation();

--- a/frontend/src/app/views/projects/components/chatErrors.js
+++ b/frontend/src/app/views/projects/components/chatErrors.js
@@ -1,0 +1,27 @@
+// Maps chat HTTP failures to user-facing messages. Called from both the
+// streaming and non-streaming error paths in ChatPanel so messaging is
+// consistent regardless of transport. Kept dependency-free so it can be
+// unit-tested without pulling in the ChatPanel component tree.
+export function formatChatError(t, status, detail) {
+  const d = (detail || "").toString().trim();
+  switch (status) {
+    case 401: return t("chat.error.sessionExpired");
+    case 402: return t("chat.error.budgetExhausted");
+    case 403: return d || t("chat.error.forbidden");
+    case 404: return t("chat.error.notFound");
+    case 413: return t("chat.error.tooLarge");
+    case 422: return d ? t("chat.error.invalidDetail", { detail: d }) : t("chat.error.invalid");
+    case 429:
+      if (d && d.toLowerCase().includes("quota"))
+        return t("chat.error.quotaReached", { detail: d });
+      return t("chat.error.rateLimit");
+    case 500: return t("chat.error.internal");
+    case 502:
+    case 503:
+      return t("chat.error.overloaded");
+    case 504: return t("chat.error.timeout");
+    default:
+      if (d) return t("chat.error.default", { detail: d });
+      return t("chat.error.generic");
+  }
+}

--- a/frontend/src/app/views/projects/components/chatErrors.test.js
+++ b/frontend/src/app/views/projects/components/chatErrors.test.js
@@ -1,0 +1,44 @@
+import { formatChatError } from "./chatErrors";
+
+// i18n `t` stub: returns the key, appending interpolated detail so tests can
+// assert both the key chosen and the detail plumbed through.
+const t = (key, params) => (params?.detail ? `${key}:${params.detail}` : key);
+
+describe("formatChatError", () => {
+  it("maps auth/billing/limit statuses to their specific messages", () => {
+    expect(formatChatError(t, 401, "")).toBe("chat.error.sessionExpired");
+    expect(formatChatError(t, 402, "")).toBe("chat.error.budgetExhausted");
+    expect(formatChatError(t, 404, "")).toBe("chat.error.notFound");
+    expect(formatChatError(t, 413, "")).toBe("chat.error.tooLarge");
+    expect(formatChatError(t, 500, "")).toBe("chat.error.internal");
+    expect(formatChatError(t, 504, "")).toBe("chat.error.timeout");
+  });
+
+  it("prefers the server detail for 403, falling back to generic", () => {
+    expect(formatChatError(t, 403, "no access to this project")).toBe("no access to this project");
+    expect(formatChatError(t, 403, "")).toBe("chat.error.forbidden");
+  });
+
+  it("maps 429 to quota when the detail mentions quota, rate limit otherwise", () => {
+    expect(formatChatError(t, 429, "Monthly token QUOTA exceeded"))
+      .toBe("chat.error.quotaReached:Monthly token QUOTA exceeded");
+    expect(formatChatError(t, 429, "slow down")).toBe("chat.error.rateLimit");
+    expect(formatChatError(t, 429, "")).toBe("chat.error.rateLimit");
+  });
+
+  it("maps both 502 and 503 to overloaded", () => {
+    expect(formatChatError(t, 502, "")).toBe("chat.error.overloaded");
+    expect(formatChatError(t, 503, "")).toBe("chat.error.overloaded");
+  });
+
+  it("includes detail on 422 when present", () => {
+    expect(formatChatError(t, 422, "bad payload")).toBe("chat.error.invalidDetail:bad payload");
+    expect(formatChatError(t, 422, "")).toBe("chat.error.invalid");
+  });
+
+  it("falls back to detail or generic for unknown statuses", () => {
+    expect(formatChatError(t, 418, "teapot")).toBe("chat.error.default:teapot");
+    expect(formatChatError(t, 418, "")).toBe("chat.error.generic");
+    expect(formatChatError(t, undefined, null)).toBe("chat.error.generic");
+  });
+});

--- a/frontend/src/app/views/projects/components/projectOptionValidators.test.js
+++ b/frontend/src/app/views/projects/components/projectOptionValidators.test.js
@@ -1,0 +1,67 @@
+import { clientValidators, makeErrorFor } from "./projectOptionValidators";
+
+describe("clientValidators", () => {
+  it.each(["", null, undefined])("treats %p as valid (unset) everywhere", (v) => {
+    for (const validator of Object.values(clientValidators)) {
+      expect(validator(v)).toBe("");
+    }
+  });
+
+  it("bounds rate_limit to 1..10000", () => {
+    expect(clientValidators.rate_limit(1)).toBe("");
+    expect(clientValidators.rate_limit(10000)).toBe("");
+    expect(clientValidators.rate_limit(0)).not.toBe("");
+    expect(clientValidators.rate_limit(10001)).not.toBe("");
+    expect(clientValidators.rate_limit("abc")).not.toBe("");
+  });
+
+  it("requires k >= 1", () => {
+    expect(clientValidators.k(1)).toBe("");
+    expect(clientValidators.k(50)).toBe("");
+    expect(clientValidators.k(0)).not.toBe("");
+    expect(clientValidators.k(-1)).not.toBe("");
+  });
+
+  it("bounds score to 0..1", () => {
+    expect(clientValidators.score(0)).toBe("");
+    expect(clientValidators.score(0.5)).toBe("");
+    expect(clientValidators.score(1)).toBe("");
+    expect(clientValidators.score(1.5)).not.toBe("");
+    expect(clientValidators.score(-0.1)).not.toBe("");
+  });
+
+  it("bounds memory_bank_max_tokens to 200..10000", () => {
+    expect(clientValidators.memory_bank_max_tokens(200)).toBe("");
+    expect(clientValidators.memory_bank_max_tokens(10000)).toBe("");
+    expect(clientValidators.memory_bank_max_tokens(199)).not.toBe("");
+    expect(clientValidators.memory_bank_max_tokens(10001)).not.toBe("");
+  });
+});
+
+describe("makeErrorFor", () => {
+  it("returns the server error when present, verbatim", () => {
+    const errorFor = makeErrorFor({ rate_limit: "server says no" }, { options: { rate_limit: 5 } });
+    expect(errorFor("rate_limit")).toBe("server says no");
+  });
+
+  it("accepts options.-prefixed server keys (nested Pydantic locs)", () => {
+    const errorFor = makeErrorFor({ "options.k": "k is broken" }, { options: { k: 5 } });
+    expect(errorFor("k")).toBe("k is broken");
+  });
+
+  it("falls back to the client validator when no server error", () => {
+    const errorFor = makeErrorFor({}, { options: { rate_limit: 0 } });
+    expect(errorFor("rate_limit")).toMatch(/between 1 and 10000/);
+  });
+
+  it("returns empty for unknown fields and valid values", () => {
+    const errorFor = makeErrorFor({}, { options: { rate_limit: 10 } });
+    expect(errorFor("rate_limit")).toBe("");
+    expect(errorFor("no_such_field")).toBe("");
+  });
+
+  it("survives null fieldErrors and missing state", () => {
+    const errorFor = makeErrorFor(null, undefined);
+    expect(errorFor("rate_limit")).toBe("");
+  });
+});

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";


### PR DESCRIPTION
Follow-up to #203 — the frontend testing story, built up over several rounds including a four-agent parallel sweep.

## What's included

- **Jest via `react-scripts`** (CRA built-in) + Testing Library devDeps; setup in `src/setupTests.js`; `npm run test:ci` / `make frontend-test` runs headless with coverage; CI runs frontend tests before the build.
- **307 tests across 53 suites, all passing** (~2 min with coverage).
- **Coverage: 0% → 19.0% statements / 19.5% lines**, with a `coverageThreshold` ratchet (18/14/14/18) so CI blocks regressions; bump the floor as coverage grows.

## Coverage by area

- **Core plumbing**: `api.js` client (96%) — 422 `fieldErrors` parsing, 401 redirect flow, silent option; `JWTAuthContext` (89%) — login/TOTP/logout/impersonation/roles; Platform/TeamBranding/Settings contexts (94–100%).
- **Login**: `JwtLogin` (98%) — progressive disclosure, session-expired banner, TOTP step incl. recovery codes, SSO buttons, `auth_disable_local`.
- **Account security**: `TwoFactorAuth` (91%) — full setup/enable/disable/enforced flows; `Password`, `DeleteAccount`, `ApiKeys` (quota dialogs, scoped key creation, key reveal), `BasicInformation`, `UserActivity`, user `Projects`/`Teams`.
- **Teams & billing**: `MemberBudgetDialog`, `TopUpBalanceDialog`, `PaymentCheckoutDialog` (hosted checkout handoff), `TeamWallet` (ledger, auto-recharge setup/toggle/thresholds, payment-return redirect), `Teams` list.
- **LLM admin**: the delete-with-reassign flow in `llms/List` — zero-usage confirm path, reassign dialog with affected projects, `?reassign_to=` delete, no-replacement lockout.
- **Dashboard**: SmartSearch (query flow, loading windows, structured-query headers, errors), stats/tables/hero/fleet, and all six chart components (echarts/recharts stubbed, assertions on aggregated data wiring and insight-pill math).
- **Shared component library**: DataList (search/sort/pagination/bulk actions), Brand, Footer, Breadcrumb, ErrorBoundary, MatxMenu, Typography family, Loadable/Suspense, and more; `useSettings` hook; `csvExport`/`utils`/`projectOptionValidators`/`chatErrors` pure modules at 100%.

## Real bugs found by the tests — all fixed in this PR

1. `getTimeDifference` divided by **3660** instead of 3600 — "2 hours ago" rendered as "1 h".
2. `JwtLogin`'s GlassCard forwarded its transient `shaking` prop to the DOM (React warning on every failed login).
3. `BasicInformation`: the SSO field bound `value` to the immutable prop while `onChange` wrote to state — typing showed nothing and only the last keystroke would be PATCHed. Now a working controlled input (regression-tested).
4. `Projects` (user profile): associate/dissociate mutated `user.projects` in place; now derives an explicit list for the PATCH (regression test asserts the prop is untouched).
5. `ProjectsTable`: Gravatar hash computed from the username; now uses the lowercased/trimmed email with username fallback, per Gravatar spec.
6. `SmartSearch`: keyboard focus lost after each search (input disabled in flight); focus now restored when loading clears.
7. DOM prop leaks: `Typography`'s `ellipsis`, `AvatarBadge`'s `width`/`height` (now stripped via `shouldForwardProp`), and `ChatAvatar`'s dead `status` prop (removed).

## Notable structural change

`formatChatError` extracted from `ChatPanel.jsx` to `chatErrors.js` — react-markdown (in ChatPanel's tree) is ESM-only and breaks under CRA's Jest transform; testable logic lives outside such components (pattern documented in CLAUDE.md). ESM-only deps encountered in the sweep (`boring-avatars`, chart libs) are stubbed via `jest.mock` in tests. Production build verified. Also pinned `@babel/plugin-proposal-private-property-in-object` (CRA's "may break at any time" warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDhwNEsAPLBswKQAVqruuV