### PR TITLE
Test coverage expansion: backend 48→62%, frontend 0.9→50%; 13 bug fixes + 8 new bugs documented

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,10 +23,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "statements": 7,
-        "branches": 5,
-        "functions": 4,
-        "lines": 7
+        "statements": 18,
+        "branches": 14,
+        "functions": 14,
+        "lines": 18
       }
     }
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,15 @@
     "collectCoverageFrom": [
       "src/app/**/*.{js,jsx}",
       "!src/app/locales/**"
-    ]
+    ],
+    "coverageThreshold": {
+      "global": {
+        "statements": 7,
+        "branches": 5,
+        "functions": 4,
+        "lines": 7
+      }
+    }
   },
   "browserslist": {
     "production": [

--- a/frontend/src/app/components/Brand.test.jsx
+++ b/frontend/src/app/components/Brand.test.jsx
@@ -1,0 +1,108 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Brand from "./Brand";
+import { usePlatformCapabilities } from "app/contexts/PlatformContext";
+import { useTeamBranding } from "app/contexts/TeamBrandingContext";
+
+jest.mock("app/contexts/PlatformContext", () => ({
+  usePlatformCapabilities: jest.fn(),
+}));
+jest.mock("app/contexts/TeamBrandingContext", () => ({
+  useTeamBranding: jest.fn(),
+}));
+// The components barrel pulls in the whole layout tree; stub the only
+// piece Brand needs.
+jest.mock("app/components", () => ({
+  MatxLogo: () => {
+    const React = require("react");
+    return React.createElement("div", { "data-testid": "matx-logo" });
+  },
+}));
+
+const brandingState = (overrides = {}) => ({
+  branding: null,
+  brandedTeams: [],
+  activeTeamId: null,
+  setActiveTeamId: jest.fn(),
+  ...overrides,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  usePlatformCapabilities.mockReturnValue({
+    platformCapabilities: { app_name: "PlatformApp" },
+  });
+  useTeamBranding.mockReturnValue(brandingState());
+});
+
+describe("Brand", () => {
+  it("falls back to the platform app name and default logo", () => {
+    render(<Brand onToggleSidenav={jest.fn()} />);
+    expect(screen.getByText("PlatformApp")).toBeInTheDocument();
+    expect(screen.getByTestId("matx-logo")).toBeInTheDocument();
+  });
+
+  it("prefers the team branding app name and logo", () => {
+    useTeamBranding.mockReturnValue(
+      brandingState({
+        branding: { app_name: "TeamApp", logo_url: "https://x/logo.png" },
+      })
+    );
+    render(<Brand onToggleSidenav={jest.fn()} />);
+    expect(screen.getByText("TeamApp")).toBeInTheDocument();
+    expect(screen.queryByTestId("matx-logo")).not.toBeInTheDocument();
+    expect(screen.getByAltText("logo")).toHaveAttribute("src", "https://x/logo.png");
+  });
+
+  it("defaults to RESTai when nothing configures a name", () => {
+    usePlatformCapabilities.mockReturnValue({ platformCapabilities: {} });
+    render(<Brand onToggleSidenav={jest.fn()} />);
+    expect(screen.getByText("RESTai")).toBeInTheDocument();
+  });
+
+  it("toggles the sidenav from both the logo badge and the collapse button", async () => {
+    const user = userEvent.setup();
+    const onToggle = jest.fn();
+    render(<Brand onToggleSidenav={onToggle} />);
+
+    await user.click(screen.getByTestId("matx-logo"));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button"));
+    expect(onToggle).toHaveBeenCalledTimes(2);
+  });
+
+  it("hides the team switcher with fewer than two branded teams", () => {
+    useTeamBranding.mockReturnValue(
+      brandingState({ brandedTeams: [{ id: 1, name: "Solo", branding: null }] })
+    );
+    render(<Brand onToggleSidenav={jest.fn()} />);
+    // Only the collapse button — no switcher.
+    expect(screen.getAllByRole("button")).toHaveLength(1);
+  });
+
+  it("opens the switcher menu and selects a team", async () => {
+    const user = userEvent.setup();
+    const setActiveTeamId = jest.fn();
+    useTeamBranding.mockReturnValue(
+      brandingState({
+        brandedTeams: [
+          { id: 1, name: "Alpha", branding: { app_name: "Alpha-App" } },
+          { id: 2, name: "Beta", branding: null },
+        ],
+        activeTeamId: 1,
+        setActiveTeamId,
+      })
+    );
+    render(<Brand onToggleSidenav={jest.fn()} />);
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(2); // switcher + collapse
+    await user.click(buttons[0]);
+
+    // Menu shows branding app_name when present, team name otherwise.
+    expect(screen.getByRole("menuitem", { name: "Alpha-App" })).toBeInTheDocument();
+    await user.click(screen.getByRole("menuitem", { name: "Beta" }));
+    expect(setActiveTeamId).toHaveBeenCalledWith(2);
+  });
+});

--- a/frontend/src/app/components/ChatAvatar.jsx
+++ b/frontend/src/app/components/ChatAvatar.jsx
@@ -5,7 +5,7 @@ const StyledAvatar = styled(Avatar)({
   width: 40
 });
 
-export default function ChatAvatar({ src, status }) {
+export default function ChatAvatar({ src }) {
   return (
     <Box position="relative">
       <StyledAvatar src={src} />

--- a/frontend/src/app/components/ChatAvatar.test.jsx
+++ b/frontend/src/app/components/ChatAvatar.test.jsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import ChatAvatar from "./ChatAvatar";
+
+describe("ChatAvatar", () => {
+  it("renders an avatar image for the given src", () => {
+    render(<ChatAvatar src="/face.png" />);
+    expect(screen.getByRole("img")).toHaveAttribute("src", "/face.png");
+  });
+
+  it("renders the generic fallback avatar without a src", () => {
+    const { container } = render(<ChatAvatar />);
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    expect(container.querySelector(".MuiAvatar-root")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/components/DataList.test.jsx
+++ b/frontend/src/app/components/DataList.test.jsx
@@ -1,0 +1,169 @@
+import { render, screen, within, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import DataList from "./DataList";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (k, opts) => (opts && opts.count !== undefined ? `${k}:${opts.count}` : k),
+  }),
+}));
+
+const columns = [
+  { key: "name", label: "Name", sortable: true },
+  { key: "meta.level", label: "Level" },
+  { key: "size", label: "Size", sortable: true },
+];
+
+const data = [
+  { id: 1, name: "banana", size: 3, meta: { level: "low" } },
+  { id: 2, name: "apple", size: 9, meta: { level: "high" } },
+  { id: 3, name: "cherry", size: 1, meta: { level: "low" } },
+];
+
+const bodyRows = () => {
+  const rows = screen.getAllByRole("row");
+  // First row is the header.
+  return rows.slice(1);
+};
+
+describe("DataList", () => {
+  it("renders title, subtitle, headers, plain and nested cell values", () => {
+    render(<DataList title="Fruits" subtitle="all of them" data={data} columns={columns} />);
+    expect(screen.getByText("Fruits")).toBeInTheDocument();
+    expect(screen.getByText("all of them")).toBeInTheDocument();
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("banana")).toBeInTheDocument();
+    expect(screen.getAllByText("low")).toHaveLength(2); // nested meta.level
+    expect(bodyRows()).toHaveLength(3);
+  });
+
+  it("shows the default empty message with no data", () => {
+    render(<DataList data={[]} columns={columns} />);
+    expect(screen.getByText("dataList.noResults")).toBeInTheDocument();
+  });
+
+  it("shows a custom emptyState with an action button", async () => {
+    const user = userEvent.setup();
+    const onAction = jest.fn();
+    render(
+      <DataList
+        data={[]}
+        columns={columns}
+        emptyState={{ title: "Nothing here", message: "Add one", actionLabel: "Create", onAction }}
+      />
+    );
+    expect(screen.getByText("Nothing here")).toBeInTheDocument();
+    expect(screen.getByText("Add one")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Create" }));
+    expect(onAction).toHaveBeenCalled();
+  });
+
+  it("filters rows by search and can clear back", async () => {
+    const user = userEvent.setup();
+    render(<DataList data={data} columns={columns} searchKeys={["name"]} />);
+    const input = screen.getByPlaceholderText("dataList.search");
+
+    await user.type(input, "app");
+    expect(bodyRows()).toHaveLength(1);
+    expect(screen.getByText("apple")).toBeInTheDocument();
+    expect(screen.getByText("common.resultCount:1")).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("dataList.clearSearch"));
+    expect(bodyRows()).toHaveLength(3);
+  });
+
+  it("shows the no-matches empty state when a search finds nothing", async () => {
+    const user = userEvent.setup();
+    render(<DataList data={data} columns={columns} searchKeys={["name"]} />);
+    await user.type(screen.getByPlaceholderText("dataList.search"), "zzz");
+    expect(screen.getByText("dataList.noMatches")).toBeInTheDocument();
+  });
+
+  it("sorts by a sortable column and toggles direction on second click", async () => {
+    const user = userEvent.setup();
+    render(<DataList data={data} columns={columns} />);
+    await user.click(screen.getByText("Name"));
+    let rows = bodyRows();
+    expect(within(rows[0]).getByText("apple")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Name"));
+    rows = bodyRows();
+    expect(within(rows[0]).getByText("cherry")).toBeInTheDocument();
+  });
+
+  it("sorts numerically via defaultSort", () => {
+    render(
+      <DataList data={data} columns={columns} defaultSort={{ key: "size", direction: "desc" }} />
+    );
+    const rows = bodyRows();
+    expect(within(rows[0]).getByText("apple")).toBeInTheDocument(); // size 9
+    expect(within(rows[2]).getByText("cherry")).toBeInTheDocument(); // size 1
+  });
+
+  it("invokes onRowClick with the row, but not for clicks on inner buttons", async () => {
+    const user = userEvent.setup();
+    const onRowClick = jest.fn();
+    const action = jest.fn();
+    render(
+      <DataList
+        data={data}
+        columns={columns}
+        onRowClick={onRowClick}
+        actions={(row) => (
+          <button onClick={() => action(row.id)}>act-{row.id}</button>
+        )}
+      />
+    );
+
+    await user.click(screen.getByText("banana"));
+    expect(onRowClick).toHaveBeenCalledWith(data[0]);
+
+    onRowClick.mockClear();
+    await user.click(screen.getByRole("button", { name: "act-2" }));
+    expect(action).toHaveBeenCalledWith(2);
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it("paginates when rows exceed the page size", async () => {
+    const user = userEvent.setup();
+    const many = Array.from({ length: 12 }, (_, i) => ({ id: i, name: `row-${i}`, size: i }));
+    render(<DataList data={many} columns={columns} pageSize={10} />);
+
+    expect(bodyRows()).toHaveLength(10);
+    await user.click(screen.getByRole("button", { name: /next page/i }));
+    expect(bodyRows()).toHaveLength(2);
+    expect(screen.getByText("row-11")).toBeInTheDocument();
+  });
+
+  it("selects rows and runs a bulk action over them, then clears the selection", async () => {
+    const user = userEvent.setup();
+    const onBulk = jest.fn().mockResolvedValue();
+    render(
+      <DataList
+        data={data}
+        columns={columns}
+        bulkActions={[{ label: "Zap", onClick: onBulk }]}
+      />
+    );
+
+    await user.click(screen.getByLabelText("select row 1"));
+    await user.click(screen.getByLabelText("select row 3"));
+    expect(screen.getByText("dataList.selected:2")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Zap" }));
+    expect(onBulk).toHaveBeenCalledWith([data[0], data[2]]);
+    // Selection cleared after the action resolves.
+    expect(await screen.findByLabelText("select row 1")).not.toBeChecked();
+    expect(screen.queryByText("dataList.selected:2")).not.toBeInTheDocument();
+  });
+
+  it("select-all checkbox toggles every row on the page", () => {
+    render(
+      <DataList data={data} columns={columns} bulkActions={[{ label: "X", onClick: jest.fn() }]} />
+    );
+    fireEvent.click(screen.getByLabelText("select all on page"));
+    expect(screen.getByText("dataList.selected:3")).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("select all on page"));
+    expect(screen.queryByText(/dataList\.selected/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/components/FlexBox.test.jsx
+++ b/frontend/src/app/components/FlexBox.test.jsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { FlexBox, FlexBetween, FlexAlignCenter, FlexJustifyCenter } from "./FlexBox";
+
+describe("FlexBox variants", () => {
+  it("FlexBox renders children with display flex", () => {
+    render(<FlexBox data-testid="fb">child</FlexBox>);
+    const el = screen.getByTestId("fb");
+    expect(el).toHaveTextContent("child");
+    expect(el).toHaveStyle({ display: "flex" });
+  });
+
+  it("FlexBetween aligns center and spaces between", () => {
+    render(<FlexBetween data-testid="fb">x</FlexBetween>);
+    const el = screen.getByTestId("fb");
+    expect(el).toHaveStyle({
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+    });
+  });
+
+  it("FlexAlignCenter centers on both axes", () => {
+    render(<FlexAlignCenter data-testid="fb">x</FlexAlignCenter>);
+    const el = screen.getByTestId("fb");
+    expect(el).toHaveStyle({
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+    });
+  });
+
+  it("FlexJustifyCenter centers horizontally only", () => {
+    render(<FlexJustifyCenter data-testid="fb">x</FlexJustifyCenter>);
+    const el = screen.getByTestId("fb");
+    expect(el).toHaveStyle({ display: "flex", justifyContent: "center" });
+  });
+});

--- a/frontend/src/app/components/Footer.test.jsx
+++ b/frontend/src/app/components/Footer.test.jsx
@@ -1,0 +1,94 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import Footer from "./Footer";
+import useAuth from "app/hooks/useAuth";
+import api from "app/utils/api";
+import { usePlatformCapabilities } from "app/contexts/PlatformContext";
+
+jest.mock("app/hooks/useAuth", () => jest.fn());
+jest.mock("app/utils/api", () => ({ get: jest.fn() }));
+jest.mock("app/contexts/PlatformContext", () => ({
+  usePlatformCapabilities: jest.fn(),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  usePlatformCapabilities.mockReturnValue({
+    platformCapabilities: { hide_branding: false },
+  });
+  useAuth.mockReturnValue({ isAuthenticated: false, user: null });
+  api.get.mockResolvedValue({});
+});
+
+describe("Footer", () => {
+  it("shows the branding line and Source link when branding is visible", () => {
+    render(<Footer />);
+    expect(screen.getByText(/Powered by/i)).toBeInTheDocument();
+    const source = screen.getByRole("link", { name: /source/i });
+    expect(source).toHaveAttribute("href", "https://github.com/apocas/restai");
+  });
+
+  it("hides the branding line when hide_branding is set", () => {
+    usePlatformCapabilities.mockReturnValue({
+      platformCapabilities: { hide_branding: true },
+    });
+    render(<Footer />);
+    expect(screen.queryByText(/Powered by/i)).not.toBeInTheDocument();
+    // Source link stays regardless.
+    expect(screen.getByRole("link", { name: /source/i })).toBeInTheDocument();
+  });
+
+  it("does not fetch version info when unauthenticated", () => {
+    render(<Footer />);
+    expect(api.get).not.toHaveBeenCalled();
+  });
+
+  it("fetches and renders the version pill when authenticated", async () => {
+    useAuth.mockReturnValue({ isAuthenticated: true, user: { token: "tok" } });
+    api.get.mockImplementation((path) => {
+      if (path === "/version") return Promise.resolve({ version: "1.2.3" });
+      return Promise.resolve({ current: "1.2.3", update_available: false });
+    });
+
+    render(<Footer />);
+
+    const pill = await screen.findByRole("link", { name: /v\s*1\.2\.3/i });
+    expect(pill).toHaveAttribute(
+      "href",
+      "https://github.com/apocas/restai/releases/tag/v1.2.3"
+    );
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith("/version", "tok", expect.any(Object));
+      expect(api.get).toHaveBeenCalledWith("/version/check", "tok", expect.any(Object));
+    });
+    expect(screen.queryByText(/Update v/i)).not.toBeInTheDocument();
+  });
+
+  it("shows the update pill when an update is available", async () => {
+    useAuth.mockReturnValue({ isAuthenticated: true, user: { token: "tok" } });
+    api.get.mockImplementation((path) => {
+      if (path === "/version") return Promise.resolve({ version: "1.2.3" });
+      return Promise.resolve({
+        current: "1.2.3",
+        update_available: true,
+        latest: "1.3.0",
+        latest_url: "https://example.com/release",
+      });
+    });
+
+    render(<Footer />);
+
+    const update = await screen.findByRole("link", { name: /update v1\.3\.0/i });
+    expect(update).toHaveAttribute("href", "https://example.com/release");
+  });
+
+  it("survives version endpoints failing", async () => {
+    useAuth.mockReturnValue({ isAuthenticated: true, user: { token: "tok" } });
+    api.get.mockRejectedValue(new Error("boom"));
+
+    render(<Footer />);
+
+    await waitFor(() => expect(api.get).toHaveBeenCalledTimes(2));
+    expect(screen.getByText(/Powered by/i)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /v\d/ })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/components/Loadable.test.jsx
+++ b/frontend/src/app/components/Loadable.test.jsx
@@ -1,0 +1,26 @@
+import { lazy } from "react";
+import { render, screen } from "@testing-library/react";
+import Loadable from "./Loadable";
+
+describe("Loadable", () => {
+  it("returns a component that renders the wrapped component with its props", () => {
+    const Inner = ({ label }) => <div>inner:{label}</div>;
+    const Wrapped = Loadable(Inner);
+    render(<Wrapped label="abc" />);
+    expect(screen.getByText("inner:abc")).toBeInTheDocument();
+  });
+
+  it("shows the loading spinner while a lazy component is pending", () => {
+    const Wrapped = Loadable(lazy(() => new Promise(() => {})));
+    render(<Wrapped />);
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+  });
+
+  it("renders a lazy component once it resolves", async () => {
+    const Wrapped = Loadable(
+      lazy(() => Promise.resolve({ default: () => <div>lazy done</div> }))
+    );
+    render(<Wrapped />);
+    expect(await screen.findByText("lazy done")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/components/MatxDivider.test.jsx
+++ b/frontend/src/app/components/MatxDivider.test.jsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import MatxDivider from "./MatxDivider";
+
+describe("MatxDivider", () => {
+  it("renders the label inside a span when text is given", () => {
+    render(<MatxDivider text="OR" />);
+    const label = screen.getByText("OR");
+    expect(label.tagName).toBe("SPAN");
+  });
+
+  it("renders no span when text is omitted", () => {
+    const { container } = render(<MatxDivider />);
+    expect(container.querySelector("span")).toBeNull();
+  });
+
+  it("forwards sx styling to the divider root", () => {
+    const { container } = render(<MatxDivider text="hi" sx={{ marginTop: "13px" }} />);
+    const root = screen.getByText("hi").parentElement;
+    expect(root).toHaveStyle({ marginTop: "13px" });
+    expect(container.firstChild).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/components/MatxMenu.test.jsx
+++ b/frontend/src/app/components/MatxMenu.test.jsx
@@ -1,0 +1,60 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MenuItem } from "@mui/material";
+import MatxMenu from "./MatxMenu";
+import SettingsProvider from "app/contexts/SettingsContext";
+
+const renderMenu = (props = {}) =>
+  render(
+    <SettingsProvider>
+      <MatxMenu menuButton={<span>open me</span>} {...props}>
+        <MenuItem>First</MenuItem>
+        <MenuItem>Second</MenuItem>
+      </MatxMenu>
+    </SettingsProvider>
+  );
+
+describe("MatxMenu", () => {
+  it("keeps the menu closed until the anchor is clicked", () => {
+    renderMenu();
+    expect(screen.getByText("open me")).toBeInTheDocument();
+    expect(screen.queryByText("First")).not.toBeInTheDocument();
+  });
+
+  it("opens on anchor click, showing all children", async () => {
+    const user = userEvent.setup();
+    renderMenu();
+    await user.click(screen.getByText("open me"));
+    expect(screen.getByText("First")).toBeInTheDocument();
+    expect(screen.getByText("Second")).toBeInTheDocument();
+  });
+
+  it("closes after clicking an item by default", async () => {
+    const user = userEvent.setup();
+    renderMenu();
+    await user.click(screen.getByText("open me"));
+    await user.click(screen.getByText("First"));
+    await waitFor(() => {
+      expect(screen.queryByText("First")).not.toBeInTheDocument();
+    });
+  });
+
+  it("stays open on item click when shouldCloseOnItemClick is false", async () => {
+    const user = userEvent.setup();
+    renderMenu({ shouldCloseOnItemClick: false });
+    await user.click(screen.getByText("open me"));
+    await user.click(screen.getByText("First"));
+    expect(screen.getByText("First")).toBeInTheDocument();
+    expect(screen.getByText("Second")).toBeInTheDocument();
+  });
+
+  it("closes on escape", async () => {
+    const user = userEvent.setup();
+    renderMenu();
+    await user.click(screen.getByText("open me"));
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(screen.queryByText("First")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/app/components/MatxSuspense.test.jsx
+++ b/frontend/src/app/components/MatxSuspense.test.jsx
@@ -1,0 +1,34 @@
+import { lazy } from "react";
+import { render, screen } from "@testing-library/react";
+import MatxSuspense from "./MatxSuspense";
+
+// The components barrel pulls in the whole layout tree; stub the only
+// piece MatxSuspense needs.
+jest.mock("app/components", () => ({
+  MatxLoading: () => {
+    const React = require("react");
+    return React.createElement("div", { "data-testid": "matx-loading" });
+  },
+}));
+
+describe("MatxSuspense", () => {
+  it("renders ready children directly", () => {
+    render(
+      <MatxSuspense>
+        <div>ready content</div>
+      </MatxSuspense>
+    );
+    expect(screen.getByText("ready content")).toBeInTheDocument();
+    expect(screen.queryByTestId("matx-loading")).not.toBeInTheDocument();
+  });
+
+  it("shows the MatxLoading fallback while a lazy child is pending", () => {
+    const NeverReady = lazy(() => new Promise(() => {}));
+    render(
+      <MatxSuspense>
+        <NeverReady />
+      </MatxSuspense>
+    );
+    expect(screen.getByTestId("matx-loading")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/components/SmartSearch.jsx
+++ b/frontend/src/app/components/SmartSearch.jsx
@@ -79,7 +79,12 @@ export default function SmartSearch({ open, onClose }) {
   }, [open]);
 
   useEffect(() => {
-    if (!loading) return;
+    if (!loading) {
+      // The field is disabled while a search is in flight, which drops
+      // keyboard focus — hand it back so the user can refine the query.
+      if (open && inputRef.current) inputRef.current.focus();
+      return;
+    }
     let i = 0;
     setLoadingMessage(LOADING_MESSAGES[0]);
     const interval = setInterval(() => {
@@ -87,7 +92,7 @@ export default function SmartSearch({ open, onClose }) {
       setLoadingMessage(LOADING_MESSAGES[i]);
     }, 1400);
     return () => clearInterval(interval);
-  }, [loading]);
+  }, [loading, open]);
 
   const runSearch = (q) => {
     const text = (q != null ? q : query).trim();

--- a/frontend/src/app/components/SmartSearch.test.jsx
+++ b/frontend/src/app/components/SmartSearch.test.jsx
@@ -1,0 +1,219 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import SmartSearch from "./SmartSearch";
+import api from "app/utils/api";
+
+jest.mock("app/utils/api", () => ({ get: jest.fn(), post: jest.fn() }));
+jest.mock("app/hooks/useAuth", () => jest.fn());
+import useAuth from "app/hooks/useAuth";
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockNavigate,
+}));
+
+// SmartSearch enforces a MIN_LOADING_MS of 800ms before applying results,
+// rotates loading messages on a 1400ms interval, and focuses the input on a
+// 100ms timeout — fake timers keep all of that deterministic.
+const flushPromises = () => act(async () => {});
+const advance = (ms) => act(() => jest.advanceTimersByTime(ms));
+
+// Type into the search box and press Enter.
+const typeAndSearch = (text) => {
+  const input = screen.getByPlaceholderText(/Search anything/i);
+  fireEvent.change(input, { target: { value: text } });
+  fireEvent.keyDown(input, { key: "Enter" });
+};
+
+// Resolve the in-flight api promise, then jump past the min-loading delay.
+const settleSearch = async () => {
+  await flushPromises();
+  advance(800);
+};
+
+const renderSearch = (props = {}) =>
+  render(<SmartSearch open onClose={jest.fn()} {...props} />);
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.clearAllMocks();
+  useAuth.mockReturnValue({
+    user: { token: "tok", is_admin: true, username: "admin" },
+  });
+  api.post.mockResolvedValue({ results: [] });
+});
+
+afterEach(() => {
+  act(() => jest.runOnlyPendingTimers());
+  jest.useRealTimers();
+});
+
+describe("SmartSearch", () => {
+  it("renders nothing when closed", () => {
+    render(<SmartSearch open={false} onClose={jest.fn()} />);
+    expect(screen.queryByText("Smart Search")).not.toBeInTheDocument();
+  });
+
+  it("shows suggestion chips in the initial empty state", () => {
+    renderSearch();
+    expect(screen.getByText("Smart Search")).toBeInTheDocument();
+    expect(screen.getByText("Try")).toBeInTheDocument();
+    expect(screen.getByText("rag projects using gpt-4")).toBeInTheDocument();
+    expect(screen.getByText("restricted users")).toBeInTheDocument();
+    expect(api.post).not.toHaveBeenCalled();
+  });
+
+  it("does not search on Enter when the query is empty or whitespace", () => {
+    renderSearch();
+    const input = screen.getByPlaceholderText(/Search anything/i);
+    fireEvent.keyDown(input, { key: "Enter" });
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(api.post).not.toHaveBeenCalled();
+  });
+
+  it("posts the query on Enter, shows loading, then renders results", async () => {
+    api.post.mockResolvedValue({
+      results: [
+        {
+          entity: "projects",
+          id: 1,
+          name: "support-bot",
+          subtitle: "rag · gpt-4",
+          path: "/project/1",
+        },
+        { entity: "users", id: 2, name: "alice", path: "/user/alice" },
+      ],
+    });
+    renderSearch();
+    typeAndSearch("rag projects");
+
+    expect(api.post).toHaveBeenCalledWith(
+      "/search",
+      { query: "rag projects" },
+      "tok"
+    );
+    // Loading state shown while the request + min-loading window are pending.
+    expect(screen.getByText("Asking the AI...")).toBeInTheDocument();
+
+    await settleSearch();
+
+    expect(screen.queryByText("Asking the AI...")).not.toBeInTheDocument();
+    expect(screen.getByText("support-bot")).toBeInTheDocument();
+    expect(screen.getByText("rag · gpt-4")).toBeInTheDocument();
+    expect(screen.getByText("alice")).toBeInTheDocument();
+    // Entity chips use friendly labels.
+    expect(screen.getByText("Project")).toBeInTheDocument();
+    expect(screen.getByText("User")).toBeInTheDocument();
+  });
+
+  it("holds results until the 800ms minimum loading window elapses", async () => {
+    api.post.mockResolvedValue({
+      results: [{ entity: "teams", id: 3, name: "engineering", path: "/team/3" }],
+    });
+    renderSearch();
+    typeAndSearch("teams");
+
+    await flushPromises();
+    // API already resolved, but min-loading window not elapsed yet.
+    advance(500);
+    expect(screen.queryByText("engineering")).not.toBeInTheDocument();
+    expect(screen.getByText(/Asking the AI|Translating your query|Understanding what you mean|Searching the database/)).toBeInTheDocument();
+
+    advance(300);
+    expect(screen.getByText("engineering")).toBeInTheDocument();
+  });
+
+  it("rotates the loading message while waiting", async () => {
+    // Keep the request pending forever so loading stays on.
+    api.post.mockReturnValue(new Promise(() => {}));
+    renderSearch();
+    typeAndSearch("anything");
+
+    expect(screen.getByText("Asking the AI...")).toBeInTheDocument();
+    advance(1400);
+    expect(screen.getByText("Translating your query...")).toBeInTheDocument();
+    advance(1400);
+    expect(screen.getByText("Understanding what you mean...")).toBeInTheDocument();
+  });
+
+  it("runs a search when a suggestion chip is clicked", async () => {
+    renderSearch();
+    fireEvent.click(screen.getByText("restricted users"));
+    expect(api.post).toHaveBeenCalledWith(
+      "/search",
+      { query: "restricted users" },
+      "tok"
+    );
+    await settleSearch();
+  });
+
+  it("renders the structured-query header, note and warnings", async () => {
+    api.post.mockResolvedValue({
+      results: [{ entity: "projects", id: 1, name: "p1", path: "/project/1" }],
+      query: {
+        entity: "projects",
+        filters: [
+          { field: "type", op: "=", value: "rag" },
+          { field: "llm", op: "contains", value: "gpt" },
+        ],
+      },
+      note: "Interpreted loosely",
+      warnings: ["Ignored unknown field 'foo'"],
+    });
+    renderSearch();
+    typeAndSearch("rag projects using gpt");
+    await settleSearch();
+
+    expect(screen.getByText("projects")).toBeInTheDocument();
+    expect(screen.getByText('type = "rag"')).toBeInTheDocument();
+    expect(screen.getByText(/AND\s+llm contains "gpt"/)).toBeInTheDocument();
+    expect(screen.getByText("Interpreted loosely")).toBeInTheDocument();
+    expect(screen.getByText("Ignored unknown field 'foo'")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when a structured query returns no rows", async () => {
+    api.post.mockResolvedValue({
+      results: [],
+      query: { entity: "users", filters: [] },
+    });
+    renderSearch();
+    typeAndSearch("users named zorp");
+    await settleSearch();
+    expect(
+      screen.getByText("No results matching your query.")
+    ).toBeInTheDocument();
+  });
+
+  it("shows the API error detail on failure", async () => {
+    api.post.mockRejectedValue({ detail: "System LLM not configured" });
+    renderSearch();
+    typeAndSearch("anything");
+    await settleSearch();
+    expect(screen.getByText("System LLM not configured")).toBeInTheDocument();
+  });
+
+  it("falls back to a generic error message when detail is missing", async () => {
+    api.post.mockRejectedValue(new Error("network down"));
+    renderSearch();
+    typeAndSearch("anything");
+    await settleSearch();
+    expect(screen.getByText("Search failed")).toBeInTheDocument();
+  });
+
+  it("navigates to a result's path and closes the dialog on click", async () => {
+    const onClose = jest.fn();
+    api.post.mockResolvedValue({
+      results: [
+        { entity: "llms", id: 9, name: "gpt-4o", path: "/llms" },
+      ],
+    });
+    renderSearch({ onClose });
+    typeAndSearch("public llms");
+    await settleSearch();
+
+    fireEvent.click(screen.getByText("gpt-4o"));
+    expect(onClose).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith("/llms");
+  });
+});

--- a/frontend/src/app/components/Typography.jsx
+++ b/frontend/src/app/components/Typography.jsx
@@ -1,7 +1,9 @@
 import { Box, styled } from "@mui/material";
 import clsx from "clsx";
 
-const StyledBox = styled(Box)(({ ellipsis }) => ({
+const StyledBox = styled(Box, {
+  shouldForwardProp: (prop) => prop !== "ellipsis",
+})(({ ellipsis }) => ({
   textTransform: "none",
   ...(ellipsis && { whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" })
 }));

--- a/frontend/src/app/components/Typography.test.jsx
+++ b/frontend/src/app/components/Typography.test.jsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { H1, H2, H3, H4, H5, H6, Paragraph, Small, Span, Tiny } from "./Typography";
+
+describe("Typography components", () => {
+  it.each([
+    [H1, "H1", "28px"],
+    [H2, "H2", "24px"],
+    [H3, "H3", "18px"],
+    [H4, "H4", "16px"],
+    [H5, "H5", "14px"],
+    [H6, "H6", "13px"],
+  ])("heading %#. renders children in the right tag with its font size", (Comp, tag, size) => {
+    render(<Comp>hello {tag}</Comp>);
+    const el = screen.getByText(`hello ${tag}`);
+    expect(el.tagName).toBe(tag);
+    expect(el).toHaveStyle({ fontSize: size, fontWeight: 500 });
+  });
+
+  it("Paragraph renders a <p> at 14px", () => {
+    render(<Paragraph>para</Paragraph>);
+    const el = screen.getByText("para");
+    expect(el.tagName).toBe("P");
+    expect(el).toHaveStyle({ fontSize: "14px" });
+  });
+
+  it("Small renders a <small> at 12px", () => {
+    render(<Small>tiny-ish</Small>);
+    const el = screen.getByText("tiny-ish");
+    expect(el.tagName).toBe("SMALL");
+    expect(el).toHaveStyle({ fontSize: "12px" });
+  });
+
+  it("Span renders a <span>", () => {
+    render(<Span>inline</Span>);
+    expect(screen.getByText("inline").tagName).toBe("SPAN");
+  });
+
+  it("Tiny renders a <small> at 10px", () => {
+    render(<Tiny>micro</Tiny>);
+    const el = screen.getByText("micro");
+    expect(el.tagName).toBe("SMALL");
+    expect(el).toHaveStyle({ fontSize: "10px" });
+  });
+
+  it("applies ellipsis styles when the ellipsis prop is set", () => {
+    render(<H1 ellipsis="true">truncated</H1>);
+    expect(screen.getByText("truncated")).toHaveStyle({
+      whiteSpace: "nowrap",
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+    });
+  });
+
+  it("omits ellipsis styles by default", () => {
+    render(<H1>free flowing</H1>);
+    expect(screen.getByText("free flowing")).not.toHaveStyle({ whiteSpace: "nowrap" });
+  });
+
+  it("passes className and extra props through", () => {
+    render(
+      <Paragraph className="custom-cls" data-testid="para">
+        styled
+      </Paragraph>
+    );
+    const el = screen.getByTestId("para");
+    expect(el).toHaveClass("custom-cls");
+    expect(el).toHaveTextContent("styled");
+  });
+});

--- a/frontend/src/app/components/smallComponents.test.jsx
+++ b/frontend/src/app/components/smallComponents.test.jsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import SimpleCard from "./SimpleCard";
+import MatxLoading from "./MatxLoading";
+import NotFound from "app/views/sessions/NotFound";
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockNavigate,
+}));
+
+describe("SimpleCard", () => {
+  it("renders title, optional subtitle, and children", () => {
+    render(
+      <SimpleCard title="My Card" subtitle="sub here">
+        <span>body</span>
+      </SimpleCard>
+    );
+    expect(screen.getByText("My Card")).toBeInTheDocument();
+    expect(screen.getByText("sub here")).toBeInTheDocument();
+    expect(screen.getByText("body")).toBeInTheDocument();
+  });
+
+  it("renders without a subtitle", () => {
+    render(<SimpleCard title="Solo" />);
+    expect(screen.getByText("Solo")).toBeInTheDocument();
+  });
+});
+
+describe("MatxLoading", () => {
+  it("shows the logo and a progress spinner", () => {
+    render(<MatxLoading />);
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+  });
+});
+
+describe("NotFound", () => {
+  it("navigates back when Go Back is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <NotFound />
+      </MemoryRouter>
+    );
+    await user.click(screen.getByRole("button", { name: /go back/i }));
+    expect(mockNavigate).toHaveBeenCalledWith(-1);
+  });
+});

--- a/frontend/src/app/contexts/JWTAuthContext.test.jsx
+++ b/frontend/src/app/contexts/JWTAuthContext.test.jsx
@@ -182,6 +182,41 @@ describe("verifyTotp / logout", () => {
     await expect(ctx.verifyTotp("tt", "000000")).rejects.toThrow("Invalid code.");
   });
 
+  it("impersonate posts to the backend and re-checks auth as the target", async () => {
+    renderProvider();
+    await screen.findByTestId("authed");
+
+    axios.post.mockResolvedValue({ data: {} });
+    axios.get.mockResolvedValue({ data: whoamiUser({ username: "victim", impersonating: true }) });
+    await act(async () => {
+      await ctx.impersonate("victim");
+    });
+    expect(axios.post).toHaveBeenCalledWith(
+      "/auth/impersonate/victim",
+      {},
+      { withCredentials: true }
+    );
+    expect(screen.getByTestId("impersonating")).toHaveTextContent("true");
+  });
+
+  it("exitImpersonation restores the original identity", async () => {
+    renderProvider();
+    await screen.findByTestId("authed");
+
+    axios.post.mockResolvedValue({ data: {} });
+    axios.get.mockResolvedValue({ data: whoamiUser({ username: "orig-admin", is_admin: true }) });
+    await act(async () => {
+      await ctx.exitImpersonation();
+    });
+    expect(axios.post).toHaveBeenCalledWith(
+      "/auth/exit-impersonation",
+      {},
+      { withCredentials: true }
+    );
+    expect(screen.getByTestId("impersonating")).toHaveTextContent("false");
+    expect(screen.getByTestId("role")).toHaveTextContent("ADMIN");
+  });
+
   it("logout clears state and posts to the backend", async () => {
     renderProvider();
     await screen.findByTestId("authed");

--- a/frontend/src/app/hooks/useSettings.test.jsx
+++ b/frontend/src/app/hooks/useSettings.test.jsx
@@ -1,0 +1,64 @@
+import { render, screen, act } from "@testing-library/react";
+import useSettings from "./useSettings";
+import SettingsProvider from "app/contexts/SettingsContext";
+import { MatxLayoutSettings } from "app/components/MatxLayout/settings";
+
+let ctx;
+function Probe() {
+  ctx = useSettings();
+  return (
+    <div>
+      <span data-testid="theme">{ctx.settings.activeTheme}</span>
+      <span data-testid="layout">{ctx.settings.activeLayout}</span>
+    </div>
+  );
+}
+
+beforeEach(() => {
+  ctx = undefined;
+});
+
+describe("useSettings", () => {
+  it("exposes the default MatxLayoutSettings under a provider", () => {
+    render(
+      <SettingsProvider>
+        <Probe />
+      </SettingsProvider>
+    );
+    expect(screen.getByTestId("theme")).toHaveTextContent(MatxLayoutSettings.activeTheme);
+    expect(screen.getByTestId("layout")).toHaveTextContent("layout1");
+    expect(typeof ctx.updateSettings).toBe("function");
+  });
+
+  it("uses provider-supplied initial settings", () => {
+    render(
+      <SettingsProvider settings={{ ...MatxLayoutSettings, activeTheme: "purple1" }}>
+        <Probe />
+      </SettingsProvider>
+    );
+    expect(screen.getByTestId("theme")).toHaveTextContent("purple1");
+  });
+
+  it("updateSettings deep-merges updates into the current settings", () => {
+    render(
+      <SettingsProvider>
+        <Probe />
+      </SettingsProvider>
+    );
+
+    act(() => {
+      ctx.updateSettings({ activeTheme: "red" });
+    });
+    expect(screen.getByTestId("theme")).toHaveTextContent("red");
+    // Untouched keys survive the merge.
+    expect(screen.getByTestId("layout")).toHaveTextContent("layout1");
+    expect(ctx.settings.footer.show).toBe(true);
+  });
+
+  it("returns the inert default context outside a provider", () => {
+    render(<Probe />);
+    expect(ctx.settings).toBe(MatxLayoutSettings);
+    // Default updateSettings is a no-op that must not throw.
+    expect(() => ctx.updateSettings({ activeTheme: "red" })).not.toThrow();
+  });
+});

--- a/frontend/src/app/views/dashboard/shared/AIHero.test.jsx
+++ b/frontend/src/app/views/dashboard/shared/AIHero.test.jsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react";
+import AIHero from "./AIHero";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k) => k }),
+}));
+jest.mock("app/hooks/useAuth", () => jest.fn());
+import useAuth from "app/hooks/useAuth";
+
+// The component matches daily rows against today's / yesterday's UTC dates.
+const todayKey = new Date().toISOString().slice(0, 10);
+const yesterdayKey = new Date(Date.now() - 86400000)
+  .toISOString()
+  .slice(0, 10);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useAuth.mockReturnValue({ user: { username: "admin" } });
+});
+
+describe("AIHero", () => {
+  it("greets the logged-in user by name", () => {
+    const { container } = render(<AIHero />);
+    expect(container.textContent).toContain(", admin");
+    // Greeting key comes from the mocked translator.
+    expect(container.textContent).toMatch(/dashboard\.hero\.greet/);
+  });
+
+  it("omits the name suffix when there is no user", () => {
+    useAuth.mockReturnValue(null);
+    const { container } = render(<AIHero />);
+    expect(container.textContent).not.toContain(", admin");
+  });
+
+  it("always shows the operational status chip", () => {
+    render(<AIHero />);
+    expect(screen.getByText("dashboard.hero.operational")).toBeInTheDocument();
+  });
+
+  it("shows the models chip only when modelsCount is provided", () => {
+    const { rerender } = render(<AIHero />);
+    expect(
+      screen.queryByText("dashboard.hero.modelsOnline")
+    ).not.toBeInTheDocument();
+
+    rerender(<AIHero modelsCount={3} />);
+    expect(screen.getByText("dashboard.hero.modelsOnline")).toBeInTheDocument();
+  });
+
+  it("shows today's tokens and the vs-yesterday trend when both days have activity", () => {
+    render(
+      <AIHero
+        dailyTokens={[
+          { date: yesterdayKey, input_tokens: 100, output_tokens: 100 },
+          { date: todayKey, input_tokens: 300, output_tokens: 100 },
+        ]}
+      />
+    );
+    expect(screen.getByText("dashboard.hero.tokensToday")).toBeInTheDocument();
+    expect(screen.getByText("dashboard.hero.vsYesterday")).toBeInTheDocument();
+  });
+
+  it("hides activity chips on quiet days", () => {
+    render(
+      <AIHero
+        dailyTokens={[
+          { date: "2020-01-01", input_tokens: 500, output_tokens: 500 },
+        ]}
+      />
+    );
+    expect(
+      screen.queryByText("dashboard.hero.tokensToday")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("dashboard.hero.vsYesterday")
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows total tokens and latency chips from the summary", () => {
+    render(
+      <AIHero summary={{ total_tokens: 2_000_000, avg_latency_ms: 1234 }} />
+    );
+    expect(screen.getByText("dashboard.hero.totalTokens")).toBeInTheDocument();
+    expect(screen.getByText("dashboard.hero.latency")).toBeInTheDocument();
+  });
+
+  it("hides the latency chip when the summary has no latency", () => {
+    render(<AIHero summary={{ total_tokens: 10 }} />);
+    expect(
+      screen.queryByText("dashboard.hero.latency")
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/views/dashboard/shared/ActivityPulse.test.jsx
+++ b/frontend/src/app/views/dashboard/shared/ActivityPulse.test.jsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import ActivityPulse from "./ActivityPulse";
+
+jest.mock("echarts-for-react", () => {
+  const React = require("react");
+  return function MockEcharts(props) {
+    return React.createElement("div", {
+      "data-testid": "echart",
+      "data-option": JSON.stringify(props.option),
+    });
+  };
+});
+
+const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const dayName = (iso) => DAY_NAMES[new Date(iso + "T00:00:00").getDay()];
+
+// 14 consecutive days: previous week at 100 tokens/day, last week at 200
+// tokens/day (one 500-token peak) => +100%-ish trend, 14-day streak.
+function makeData() {
+  const rows = [];
+  for (let i = 0; i < 14; i++) {
+    const day = String(18 + i).padStart(2, "0");
+    const total = i < 7 ? 100 : 200;
+    rows.push({ date: `2026-07-${day}`, input_tokens: total, output_tokens: 0 });
+  }
+  rows[10].input_tokens = 500; // peak day within the last 7
+  return rows;
+}
+
+const getOption = () =>
+  JSON.parse(screen.getByTestId("echart").getAttribute("data-option"));
+
+describe("ActivityPulse", () => {
+  it("renders nothing without data", () => {
+    const { container } = render(<ActivityPulse data={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the card with rose chart limited to the last 7 days", () => {
+    render(<ActivityPulse data={makeData()} />);
+    expect(screen.getByText("Activity Pulse")).toBeInTheDocument();
+    expect(screen.getByText("30-day activity")).toBeInTheDocument();
+
+    const option = getOption();
+    expect(option.series[0].data).toHaveLength(7);
+    // Rose petals carry the weekday name + daily total.
+    expect(option.series[0].data[0].name).toBe(dayName("2026-07-25"));
+    expect(option.series[0].data[0].value).toBe(200);
+  });
+
+  it("computes peak day, trend percentage and streak insights", () => {
+    render(<ActivityPulse data={makeData()} />);
+
+    // Peak = the 500-token day (index 10 => 2026-07-28).
+    expect(screen.getByText("Peak")).toBeInTheDocument();
+    expect(screen.getByText(dayName("2026-07-28"))).toBeInTheDocument();
+
+    // last7 = 6*200 + 500 = 1700 vs prev7 = 700 => +143%.
+    expect(screen.getByText("Trend")).toBeInTheDocument();
+    expect(screen.getByText("+143%")).toBeInTheDocument();
+
+    // Every day has activity => 14-day streak.
+    expect(screen.getByText("Streak")).toBeInTheDocument();
+    expect(screen.getByText("14d")).toBeInTheDocument();
+  });
+
+  it("shows a negative trend and no streak pill after a quiet day", () => {
+    const data = makeData().map((d, i) =>
+      i < 7
+        ? d
+        : { ...d, input_tokens: i === 13 ? 0 : 50 } // last day silent
+    );
+    render(<ActivityPulse data={data} />);
+
+    // last7 = 6*50 = 300 vs prev7 = 700 => -57%.
+    expect(screen.getByText("-57%")).toBeInTheDocument();
+    // Streak broken by the trailing zero day => pill hidden (streak <= 1).
+    expect(screen.queryByText("Streak")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/views/dashboard/shared/DailyCostChart.test.jsx
+++ b/frontend/src/app/views/dashboard/shared/DailyCostChart.test.jsx
@@ -1,0 +1,88 @@
+import { render, screen } from "@testing-library/react";
+import DailyCostChart from "./DailyCostChart";
+
+jest.mock("recharts", () => {
+  const React = require("react");
+  return {
+    ResponsiveContainer: ({ children }) =>
+      React.createElement("div", { "data-testid": "container" }, children),
+    AreaChart: ({ children, data }) =>
+      React.createElement(
+        "div",
+        { "data-testid": "area-chart", "data-rows": JSON.stringify(data) },
+        // Drop raw SVG children (<defs> gradients) — only keep component
+        // children (Area/XAxis/...) so jsdom doesn't warn about SVG tags.
+        React.Children.toArray(children).filter((c) => typeof c.type !== "string")
+      ),
+    Area: (props) =>
+      React.createElement("div", {
+        "data-testid": "area",
+        "data-key": props.dataKey,
+      }),
+    XAxis: () => null,
+    YAxis: () => null,
+    CartesianGrid: () => null,
+    Tooltip: () => null,
+  };
+});
+
+const areaKeys = () =>
+  screen.getAllByTestId("area").map((a) => a.getAttribute("data-key"));
+
+describe("DailyCostChart", () => {
+  it("renders nothing without data", () => {
+    const { container } = render(<DailyCostChart data={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when every row has zero cost", () => {
+    const { container } = render(
+      <DailyCostChart
+        data={[{ date: "2026-07-31", input_cost: 0, output_cost: 0, total_cost: 0 }]}
+      />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders stacked input/output areas when split costs exist", () => {
+    render(
+      <DailyCostChart
+        data={[
+          { date: "2026-07-30", input_cost: 0.5, output_cost: 0.2 },
+          { date: "2026-07-31", input_cost: 0.7, output_cost: 0.4 },
+        ]}
+      />
+    );
+    expect(screen.getByText("Daily Cost")).toBeInTheDocument();
+    expect(areaKeys()).toEqual(["input_cost", "output_cost"]);
+  });
+
+  it("falls back to a single total_cost area when only totals exist", () => {
+    render(
+      <DailyCostChart
+        data={[{ date: "2026-07-31", total_cost: 1.25 }]}
+      />
+    );
+    expect(areaKeys()).toEqual(["total_cost"]);
+  });
+
+  it("normalizes missing cost fields to zero in the chart rows", () => {
+    render(
+      <DailyCostChart
+        data={[
+          { date: "2026-07-30", input_cost: 0.5 },
+          { date: "2026-07-31" },
+        ]}
+      />
+    );
+    const rows = JSON.parse(
+      screen.getByTestId("area-chart").getAttribute("data-rows")
+    );
+    expect(rows[1]).toEqual({
+      date: "2026-07-31",
+      input_cost: 0,
+      output_cost: 0,
+      total_cost: 0,
+    });
+  });
+});

--- a/frontend/src/app/views/dashboard/shared/DailyTokensChart.test.jsx
+++ b/frontend/src/app/views/dashboard/shared/DailyTokensChart.test.jsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import DailyTokensChart from "./DailyTokensChart";
+
+// Stub recharts — assert the data the component feeds the chart, not SVG.
+jest.mock("recharts", () => {
+  const React = require("react");
+  return {
+    ResponsiveContainer: ({ children }) =>
+      React.createElement("div", { "data-testid": "container" }, children),
+    AreaChart: ({ children, data }) =>
+      React.createElement(
+        "div",
+        { "data-testid": "area-chart", "data-rows": JSON.stringify(data) },
+        // Drop raw SVG children (<defs> gradients) — only keep component
+        // children (Area/XAxis/...) so jsdom doesn't warn about SVG tags.
+        React.Children.toArray(children).filter((c) => typeof c.type !== "string")
+      ),
+    Area: (props) =>
+      React.createElement("div", {
+        "data-testid": "area",
+        "data-key": props.dataKey,
+      }),
+    XAxis: () => null,
+    YAxis: () => null,
+    CartesianGrid: () => null,
+    Tooltip: () => null,
+  };
+});
+
+const data = [
+  { date: "2026-07-30", input_tokens: 100, output_tokens: 50 },
+  { date: "2026-07-31", input_tokens: 200, output_tokens: 80 },
+];
+
+describe("DailyTokensChart", () => {
+  it("renders nothing without data", () => {
+    const { container } = render(<DailyTokensChart data={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the title and passes the rows to the area chart", () => {
+    render(<DailyTokensChart data={data} />);
+    expect(screen.getByText("Daily Token Usage")).toBeInTheDocument();
+
+    const chart = screen.getByTestId("area-chart");
+    expect(JSON.parse(chart.getAttribute("data-rows"))).toEqual(data);
+
+    // One stacked area per token direction.
+    const keys = screen.getAllByTestId("area").map((a) => a.getAttribute("data-key"));
+    expect(keys).toEqual(["input_tokens", "output_tokens"]);
+  });
+});

--- a/frontend/src/app/views/dashboard/shared/ModelFleet.test.jsx
+++ b/frontend/src/app/views/dashboard/shared/ModelFleet.test.jsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import ModelFleet from "./ModelFleet";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k) => k }),
+}));
+
+describe("ModelFleet", () => {
+  it("renders nothing when there are no LLMs", () => {
+    const { container } = render(<ModelFleet llms={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders a card per model with compacted metrics", () => {
+    render(
+      <ModelFleet
+        llms={[
+          { name: "gpt-4o", total_tokens: 1_500_000, request_count: 42 },
+          { name: "claude-3-opus", total_tokens: 2_000, request_count: 7 },
+        ]}
+      />
+    );
+
+    expect(screen.getByText("gpt-4o")).toBeInTheDocument();
+    expect(screen.getByText("claude-3-opus")).toBeInTheDocument();
+    expect(screen.getByText("1.5M")).toBeInTheDocument();
+    expect(screen.getByText("2.0K")).toBeInTheDocument();
+    expect(screen.getByText("42")).toBeInTheDocument();
+    expect(screen.getByText("7")).toBeInTheDocument();
+  });
+
+  it("detects known providers from the model name", () => {
+    render(
+      <ModelFleet
+        llms={[
+          { name: "gpt-4o", total_tokens: 1 },
+          { name: "claude-3-opus", total_tokens: 1 },
+          { name: "gemini-1.5-pro", total_tokens: 1 },
+          { name: "mistral-large", total_tokens: 1 },
+        ]}
+      />
+    );
+    expect(screen.getByText("OpenAI")).toBeInTheDocument();
+    expect(screen.getByText("Anthropic")).toBeInTheDocument();
+    expect(screen.getByText("Google")).toBeInTheDocument();
+    expect(screen.getByText("Mistral")).toBeInTheDocument();
+  });
+
+  it("falls back to the Custom label for unknown providers", () => {
+    render(<ModelFleet llms={[{ name: "totally-unheard-of", total_tokens: 1 }]} />);
+    expect(screen.getByText("Custom")).toBeInTheDocument();
+  });
+
+  it("renders two-letter initials in the avatar", () => {
+    render(<ModelFleet llms={[{ name: "gpt-4o", total_tokens: 1 }]} />);
+    // "gpt-4o" -> letters only -> "GP"
+    expect(screen.getByText("GP")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/views/dashboard/shared/ProjectsLLMsChart.test.jsx
+++ b/frontend/src/app/views/dashboard/shared/ProjectsLLMsChart.test.jsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import ProjectsLLMsChart from "./ProjectsLLMsChart";
+
+jest.mock("echarts-for-react", () => {
+  const React = require("react");
+  return function MockEcharts(props) {
+    return React.createElement("div", {
+      "data-testid": "echart",
+      "data-option": JSON.stringify(props.option),
+    });
+  };
+});
+
+const getOption = () =>
+  JSON.parse(screen.getByTestId("echart").getAttribute("data-option"));
+
+describe("ProjectsLLMsChart", () => {
+  it("renders nothing when there are no projects", () => {
+    const { container } = render(<ProjectsLLMsChart projects={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when no project has an LLM assigned", () => {
+    const { container } = render(
+      <ProjectsLLMsChart projects={[{ name: "block-only" }, { llm: null }]} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("counts projects per LLM sorted by usage, skipping LLM-less projects", () => {
+    render(
+      <ProjectsLLMsChart
+        projects={[
+          { llm: "gpt-4" },
+          { llm: "gpt-4" },
+          { llm: "claude" },
+          { llm: "gpt-4" },
+          { name: "no-llm-block" },
+        ]}
+      />
+    );
+    const option = getOption();
+    expect(option.series[0].data).toEqual([
+      { name: "gpt-4", value: 3 },
+      { name: "claude", value: 1 },
+    ]);
+  });
+});

--- a/frontend/src/app/views/dashboard/shared/ProjectsStats.test.jsx
+++ b/frontend/src/app/views/dashboard/shared/ProjectsStats.test.jsx
@@ -1,0 +1,136 @@
+import { render, screen } from "@testing-library/react";
+import ProjectsStats from "./ProjectsStats";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k) => k }),
+}));
+
+describe("ProjectsStats", () => {
+  it("renders only the three base cards without a summary", () => {
+    render(<ProjectsStats projects={[{ type: "rag" }, { type: "agent" }]} />);
+
+    expect(screen.getByText("dashboard.stats.projects")).toBeInTheDocument();
+    expect(screen.getByText("dashboard.stats.users")).toBeInTheDocument();
+    expect(screen.getByText("dashboard.stats.teams")).toBeInTheDocument();
+    // Tokens / cost / latency cards need summary data.
+    expect(screen.queryByText("dashboard.stats.tokens")).not.toBeInTheDocument();
+    expect(screen.queryByText("dashboard.stats.cost")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("dashboard.stats.avgLatency")
+    ).not.toBeInTheDocument();
+
+    // Project count falls back to the projects array length.
+    expect(screen.getByText("2")).toBeInTheDocument();
+    // Users / teams unknown without summary.
+    expect(screen.getAllByText("—")).toHaveLength(2);
+  });
+
+  it("renders totals from the summary payload", () => {
+    render(
+      <ProjectsStats
+        projects={[]}
+        summary={{
+          total_projects: 12,
+          total_users: 5,
+          total_teams: 3,
+          total_tokens: 1_500_000,
+          total_cost: 12.345,
+        }}
+      />
+    );
+
+    expect(screen.getByText("12")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    // formatNumber compacts to one decimal + suffix.
+    expect(screen.getByText("1.5M")).toBeInTheDocument();
+    expect(screen.getByText("$12.35")).toBeInTheDocument();
+  });
+
+  it("uses the EUR symbol when currency is EUR", () => {
+    render(
+      <ProjectsStats
+        summary={{
+          total_projects: 1,
+          total_users: 1,
+          total_teams: 1,
+          total_tokens: 10,
+          total_cost: 2,
+        }}
+        currency="EUR"
+      />
+    );
+    expect(screen.getByText("€2.00")).toBeInTheDocument();
+  });
+
+  it("shows the latency card formatted in seconds above 1000ms", () => {
+    render(
+      <ProjectsStats
+        summary={{
+          total_projects: 1,
+          total_users: 1,
+          total_teams: 1,
+          total_tokens: 0,
+          total_cost: 0,
+          avg_latency_ms: 1500,
+        }}
+      />
+    );
+    expect(screen.getByText("dashboard.stats.avgLatency")).toBeInTheDocument();
+    expect(screen.getByText("1.5s")).toBeInTheDocument();
+  });
+
+  it("shows the latency card in milliseconds below 1000ms", () => {
+    render(
+      <ProjectsStats
+        summary={{
+          total_projects: 1,
+          total_users: 1,
+          total_teams: 1,
+          total_tokens: 0,
+          total_cost: 0,
+          avg_latency_ms: 250,
+        }}
+      />
+    );
+    expect(screen.getByText("250ms")).toBeInTheDocument();
+  });
+
+  it("derives average latency from dailyTokens when summary lacks it", () => {
+    render(
+      <ProjectsStats
+        summary={{
+          total_projects: 1,
+          total_users: 1,
+          total_teams: 1,
+          total_tokens: 0,
+          total_cost: 0,
+        }}
+        dailyTokens={[
+          { date: "2026-07-30", avg_latency_ms: 100 },
+          { date: "2026-07-31", avg_latency_ms: 300 },
+          // Zero-latency (quiet) days are filtered out of the average.
+          { date: "2026-08-01", avg_latency_ms: 0 },
+        ]}
+      />
+    );
+    expect(screen.getByText("200ms")).toBeInTheDocument();
+  });
+
+  it("renders the project type breakdown legend with counts", () => {
+    render(
+      <ProjectsStats
+        projects={[
+          { type: "rag" },
+          { type: "rag" },
+          { type: "agent" },
+          { type: "block" },
+        ]}
+      />
+    );
+    // Legend labels are the (mock-translated) keys, uppercased, plus counts.
+    expect(screen.getByText("PROJECTS.TYPE.RAG 2")).toBeInTheDocument();
+    expect(screen.getByText("PROJECTS.TYPE.AGENT 1")).toBeInTheDocument();
+    expect(screen.getByText("PROJECTS.TYPE.BLOCK 1")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/views/dashboard/shared/ProjectsTable.jsx
+++ b/frontend/src/app/views/dashboard/shared/ProjectsTable.jsx
@@ -288,7 +288,7 @@ export default function ProjectsTable({ projects = [], title = "Projects", compa
                     {users.slice(0, 3).map((u, i) => (
                       <Tooltip key={u.id || u.username || i} title={u.username || ""} arrow>
                         <Avatar
-                          src={`https://www.gravatar.com/avatar/${sha256(u.username || "")}?d=identicon`}
+                          src={`https://www.gravatar.com/avatar/${sha256((u.email || u.username || "").trim().toLowerCase())}?d=identicon`}
                           sx={{
                             width: 24, height: 24,
                             ml: i === 0 ? 0 : -0.75,

--- a/frontend/src/app/views/dashboard/shared/ProjectsTable.test.jsx
+++ b/frontend/src/app/views/dashboard/shared/ProjectsTable.test.jsx
@@ -1,0 +1,104 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import ProjectsTable from "./ProjectsTable";
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockNavigate,
+}));
+
+const projects = [
+  {
+    id: 5,
+    name: "alpha",
+    type: "rag",
+    llm: "gpt-4",
+    team: { name: "engineering" },
+    users: [
+      { id: 1, username: "alice" },
+      { id: 2, username: "bob" },
+    ],
+  },
+  {
+    id: 7,
+    name: "beta",
+    type: "agent",
+    users: [],
+  },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("ProjectsTable", () => {
+  it("shows the empty state when there are no projects", () => {
+    render(<ProjectsTable projects={[]} />);
+    expect(screen.getByText(/no projects yet/)).toBeInTheDocument();
+    expect(screen.getByText("0")).toBeInTheDocument();
+  });
+
+  it("renders the title, count badge and one row per project", () => {
+    render(<ProjectsTable projects={projects} title="Latest" />);
+    expect(screen.getByText("Latest")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("alpha")).toBeInTheDocument();
+    expect(screen.getByText("beta")).toBeInTheDocument();
+    // Type pills, LLM and team metadata.
+    expect(screen.getByText("rag")).toBeInTheDocument();
+    expect(screen.getByText("agent")).toBeInTheDocument();
+    expect(screen.getByText(/gpt-4/)).toBeInTheDocument();
+    expect(screen.getByText(/engineering/)).toBeInTheDocument();
+  });
+
+  it("navigates to the project when a row is clicked", () => {
+    render(<ProjectsTable projects={projects} />);
+    fireEvent.click(screen.getByText("alpha"));
+    expect(mockNavigate).toHaveBeenCalledWith("/project/5");
+  });
+
+  it("navigates to /projects/new from the New project button", () => {
+    render(<ProjectsTable projects={[]} />);
+    fireEvent.click(screen.getByRole("button", { name: /new project/i }));
+    expect(mockNavigate).toHaveBeenCalledWith("/projects/new");
+  });
+
+  it("hides the New project button in compact mode", () => {
+    render(<ProjectsTable projects={[]} compact />);
+    expect(
+      screen.queryByRole("button", { name: /new project/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens the playground without also triggering the row click", () => {
+    // Compact mode: the only buttons are the per-row action icons
+    // (playground first, open-project second).
+    render(<ProjectsTable projects={[projects[0]]} compact />);
+    const [playgroundBtn, openBtn] = screen.getAllByRole("button");
+
+    fireEvent.click(playgroundBtn);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith("/project/5/playground");
+
+    fireEvent.click(openBtn);
+    expect(mockNavigate).toHaveBeenCalledTimes(2);
+    expect(mockNavigate).toHaveBeenLastCalledWith("/project/5");
+  });
+
+  it("collapses more than three members into a +N overflow badge", () => {
+    const manyUsers = {
+      id: 9,
+      name: "crowded",
+      type: "block",
+      users: [
+        { id: 1, username: "u1" },
+        { id: 2, username: "u2" },
+        { id: 3, username: "u3" },
+        { id: 4, username: "u4" },
+        { id: 5, username: "u5" },
+      ],
+    };
+    render(<ProjectsTable projects={[manyUsers]} />);
+    expect(screen.getByText("+2")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/views/dashboard/shared/ProjectsTypesChart.test.jsx
+++ b/frontend/src/app/views/dashboard/shared/ProjectsTypesChart.test.jsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import ProjectsTypesChart from "./ProjectsTypesChart";
+
+// Stub the chart library — we only care about the option the component
+// computes, not the canvas ECharts would paint.
+jest.mock("echarts-for-react", () => {
+  const React = require("react");
+  return function MockEcharts(props) {
+    return React.createElement("div", {
+      "data-testid": "echart",
+      "data-option": JSON.stringify(props.option),
+    });
+  };
+});
+
+const getOption = () =>
+  JSON.parse(screen.getByTestId("echart").getAttribute("data-option"));
+
+describe("ProjectsTypesChart", () => {
+  it("renders nothing when there are no projects", () => {
+    const { container } = render(<ProjectsTypesChart projects={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("aggregates project counts by type into the pie series", () => {
+    render(
+      <ProjectsTypesChart
+        projects={[
+          { type: "rag" },
+          { type: "rag" },
+          { type: "agent" },
+          { type: "block" },
+        ]}
+      />
+    );
+    const option = getOption();
+    expect(option.series).toHaveLength(1);
+    expect(option.series[0].type).toBe("pie");
+    expect(option.series[0].data).toEqual(
+      expect.arrayContaining([
+        { name: "rag", value: 2 },
+        { name: "agent", value: 1 },
+        { name: "block", value: 1 },
+      ])
+    );
+    expect(option.series[0].data).toHaveLength(3);
+  });
+});

--- a/frontend/src/app/views/dashboard/shared/TopLLMsChart.test.jsx
+++ b/frontend/src/app/views/dashboard/shared/TopLLMsChart.test.jsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import TopLLMsChart from "./TopLLMsChart";
+
+jest.mock("recharts", () => {
+  const React = require("react");
+  return {
+    ResponsiveContainer: ({ children }) =>
+      React.createElement("div", { "data-testid": "container" }, children),
+    BarChart: ({ children, data }) =>
+      React.createElement(
+        "div",
+        { "data-testid": "bar-chart", "data-rows": JSON.stringify(data) },
+        // Drop raw SVG children (<defs> gradients) — only keep component
+        // children (Bar/XAxis/...) so jsdom doesn't warn about SVG tags.
+        React.Children.toArray(children).filter((c) => typeof c.type !== "string")
+      ),
+    Bar: (props) =>
+      React.createElement("div", {
+        "data-testid": "bar",
+        "data-key": props.dataKey,
+      }),
+    XAxis: () => null,
+    YAxis: () => null,
+    CartesianGrid: () => null,
+    Tooltip: () => null,
+  };
+});
+
+describe("TopLLMsChart", () => {
+  it("renders nothing without data", () => {
+    const { container } = render(<TopLLMsChart data={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the title and feeds rows into the token bar", () => {
+    const data = [
+      { name: "gpt-4", total_tokens: 5000, request_count: 12 },
+      { name: "claude", total_tokens: 3000, request_count: 8 },
+    ];
+    render(<TopLLMsChart data={data} />);
+
+    expect(screen.getByText("Top LLMs")).toBeInTheDocument();
+    expect(
+      JSON.parse(screen.getByTestId("bar-chart").getAttribute("data-rows"))
+    ).toEqual(data);
+    expect(screen.getByTestId("bar").getAttribute("data-key")).toBe(
+      "total_tokens"
+    );
+  });
+});

--- a/frontend/src/app/views/dashboard/shared/TopProjectsTable.test.jsx
+++ b/frontend/src/app/views/dashboard/shared/TopProjectsTable.test.jsx
@@ -1,0 +1,82 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import TopProjectsTable from "./TopProjectsTable";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k) => k }),
+}));
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockNavigate,
+}));
+
+const projects = [
+  {
+    id: 1,
+    name: "leader",
+    type: "rag",
+    llm: "gpt-4",
+    input_tokens: 1000,
+    output_tokens: 500,
+    total_cost: 0.1234,
+  },
+  {
+    id: 2,
+    name: "runner-up",
+    type: "agent",
+    input_tokens: 300,
+    output_tokens: 100,
+    total_cost: 0.05,
+  },
+  { id: 3, name: "third", type: "block", input_tokens: 100, output_tokens: 0, total_cost: 0 },
+  { id: 4, name: "fourth", type: "rag", input_tokens: 50, output_tokens: 0, total_cost: 0 },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("TopProjectsTable", () => {
+  it("shows the empty state when there is no traffic", () => {
+    render(<TopProjectsTable projects={[]} />);
+    expect(screen.getByText(/no traffic yet/)).toBeInTheDocument();
+    expect(screen.getByText("0")).toBeInTheDocument();
+    // No footer without a leader.
+    expect(screen.queryByText(/leader runs/)).not.toBeInTheDocument();
+  });
+
+  it("renders ranked rows with compacted token totals and costs", () => {
+    render(<TopProjectsTable projects={projects} />);
+
+    expect(screen.getByText("leader")).toBeInTheDocument();
+    expect(screen.getByText("runner-up")).toBeInTheDocument();
+    // 1500 tokens compacts to 1.5K; sub-1000 stays numeric.
+    expect(screen.getByText(/1\.5K/)).toBeInTheDocument();
+    expect(screen.getByText(/400/)).toBeInTheDocument();
+    // Costs render with three decimals.
+    expect(screen.getByText("$0.123")).toBeInTheDocument();
+    expect(screen.getByText("$0.050")).toBeInTheDocument();
+    // Ranks past the podium show the plain number — "4" appears both as
+    // the count badge (4 projects) and the rank medal of the fourth row.
+    expect(screen.getAllByText("4")).toHaveLength(2);
+  });
+
+  it("renders the footer mini-stat for the leader", () => {
+    render(<TopProjectsTable projects={projects} />);
+    const footer = screen.getByText(/leader runs/).closest("div");
+    expect(footer).toHaveTextContent("1,500");
+    expect(footer).toHaveTextContent("$0.123");
+  });
+
+  it("uses the EUR symbol when currency is EUR", () => {
+    render(<TopProjectsTable projects={[projects[0]]} currency="EUR" />);
+    expect(screen.getAllByText(/€0\.123/).length).toBeGreaterThan(0);
+  });
+
+  it("navigates to the project on row click", () => {
+    render(<TopProjectsTable projects={projects} />);
+    fireEvent.click(screen.getByText("runner-up"));
+    expect(mockNavigate).toHaveBeenCalledWith("/project/2");
+  });
+});

--- a/frontend/src/app/views/llms/List.test.jsx
+++ b/frontend/src/app/views/llms/List.test.jsx
@@ -1,0 +1,184 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import LLMs from "./List";
+import api from "app/utils/api";
+import { toast } from "react-toastify";
+
+jest.mock("app/utils/api", () => ({
+  get: jest.fn(),
+  post: jest.fn(),
+  patch: jest.fn(),
+  delete: jest.fn(),
+}));
+jest.mock("react-toastify", () => ({ toast: { success: jest.fn(), error: jest.fn() } }));
+jest.mock("react-i18next", () => ({ useTranslation: () => ({ t: (k) => k }) }));
+jest.mock("app/hooks/useAuth", () => jest.fn());
+import useAuth from "app/hooks/useAuth";
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+// Kept to 2 rows — DataList renders fast, but small fixtures keep intent clear.
+// Default sort is id desc, so row order is: claude (id 2), gpt4 (id 1).
+const LLMS = [
+  { id: 1, name: "gpt4", class_name: "OpenAI", privacy: "public", context_window: 128000, input_cost: 2.5, output_cost: 10 },
+  { id: 2, name: "claude", class_name: "Anthropic", privacy: "private", context_window: 200000 },
+];
+
+let llmsResp;
+let usageResp;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useAuth.mockReturnValue({ user: { token: "tok", username: "admin", is_admin: true } });
+  llmsResp = LLMS;
+  usageResp = { count: 0, projects: [] };
+  api.get.mockImplementation((path) => {
+    if (path === "/llms") return Promise.resolve(llmsResp);
+    if (/^\/llms\/\d+\/usage$/.test(path)) return Promise.resolve(usageResp);
+    return Promise.resolve({});
+  });
+  api.delete.mockResolvedValue({});
+  window.confirm = jest.fn(() => true);
+});
+
+const renderList = async () => {
+  render(<LLMs />);
+  // wait for the fetched rows to land
+  await screen.findByText(llmsResp[0]?.name || "llms.emptyTitle");
+};
+
+// The delete icon for the top row (claude, id 2 — first because of id-desc sort).
+const clickDeleteOnFirstRow = async (user) => {
+  const buttons = await screen.findAllByRole("button", { name: "llms.actions.delete" });
+  await user.click(buttons[0]);
+};
+
+describe("LLMs List", () => {
+  it("fetches and renders the LLM rows", async () => {
+    await renderList();
+    expect(api.get).toHaveBeenCalledWith("/llms", "tok");
+    expect(screen.getByText("gpt4")).toBeInTheDocument();
+    expect(screen.getByText("claude")).toBeInTheDocument();
+    expect(screen.getByText("LLM/0002")).toBeInTheDocument();
+  });
+
+  it("hides delete/edit actions from non-admins", async () => {
+    useAuth.mockReturnValue({ user: { token: "tok", username: "joe", is_admin: false } });
+    await renderList();
+    expect(screen.queryByRole("button", { name: "llms.actions.delete" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "llms.actions.edit" })).not.toBeInTheDocument();
+  });
+
+  it("zero-usage delete: checks usage, confirms, deletes without reassign query", async () => {
+    const user = userEvent.setup();
+    await renderList();
+
+    await clickDeleteOnFirstRow(user);
+
+    await waitFor(() => expect(api.get).toHaveBeenCalledWith("/llms/2/usage", "tok"));
+    expect(window.confirm).toHaveBeenCalledWith("llms.info.deleteConfirm");
+    await waitFor(() => expect(api.delete).toHaveBeenCalledWith("/llms/2", "tok"));
+    expect(toast.success).toHaveBeenCalledWith("llms.info.deleted");
+    // no reassign dialog
+    expect(screen.queryByText("llms.reassign.title")).not.toBeInTheDocument();
+    // list refetched after delete
+    await waitFor(() => {
+      const listCalls = api.get.mock.calls.filter(([p]) => p === "/llms");
+      expect(listCalls).toHaveLength(2);
+    });
+  });
+
+  it("zero-usage delete aborted by confirm does nothing", async () => {
+    window.confirm = jest.fn(() => false);
+    const user = userEvent.setup();
+    await renderList();
+
+    await clickDeleteOnFirstRow(user);
+
+    await waitFor(() => expect(api.get).toHaveBeenCalledWith("/llms/2/usage", "tok"));
+    expect(api.delete).not.toHaveBeenCalled();
+  });
+
+  it("non-zero usage opens the reassign dialog listing affected projects instead of confirm", async () => {
+    usageResp = {
+      count: 2,
+      projects: [
+        { id: 10, name: "proj-a", human_name: "Proj A", fields: ["llm"] },
+        { id: 11, name: "proj-b", fields: ["rerank_llm"] },
+      ],
+    };
+    const user = userEvent.setup();
+    await renderList();
+
+    await clickDeleteOnFirstRow(user);
+
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("llms.reassign.title")).toBeInTheDocument();
+    // no plain confirm, no delete yet
+    expect(window.confirm).not.toHaveBeenCalled();
+    expect(api.delete).not.toHaveBeenCalled();
+    // affected projects listed (human_name preferred, name as fallback)
+    expect(within(dialog).getByText("Proj A")).toBeInTheDocument();
+    expect(within(dialog).getByText("proj-b")).toBeInTheDocument();
+    expect(within(dialog).getByText("(llms.reassign.field_llm)")).toBeInTheDocument();
+    expect(within(dialog).getByText("(llms.reassign.field_rerank_llm)")).toBeInTheDocument();
+    // replacement pre-selected with the first other LLM
+    expect(within(dialog).getByRole("combobox")).toHaveTextContent("gpt4");
+    expect(within(dialog).getByRole("button", { name: "llms.reassign.confirm" })).toBeEnabled();
+  });
+
+  it("confirming the reassign dialog deletes with ?reassign_to=<target> and refetches", async () => {
+    usageResp = { count: 1, projects: [{ id: 10, name: "proj-a", fields: ["llm"] }] };
+    api.delete.mockResolvedValue({ reassigned: 1, reassigned_to: "gpt4" });
+    const user = userEvent.setup();
+    await renderList();
+
+    await clickDeleteOnFirstRow(user);
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: "llms.reassign.confirm" }));
+
+    await waitFor(() =>
+      expect(api.delete).toHaveBeenCalledWith("/llms/2?reassign_to=gpt4", "tok")
+    );
+    expect(toast.success).toHaveBeenCalledWith("llms.reassign.done");
+    await waitFor(() =>
+      expect(screen.queryByText("llms.reassign.title")).not.toBeInTheDocument()
+    );
+    await waitFor(() => {
+      const listCalls = api.get.mock.calls.filter(([p]) => p === "/llms");
+      expect(listCalls).toHaveLength(2);
+    });
+  });
+
+  it("cancel closes the reassign dialog without deleting", async () => {
+    usageResp = { count: 1, projects: [{ id: 10, name: "proj-a", fields: ["llm"] }] };
+    const user = userEvent.setup();
+    await renderList();
+
+    await clickDeleteOnFirstRow(user);
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: "llms.reassign.cancel" }));
+
+    await waitFor(() =>
+      expect(screen.queryByText("llms.reassign.title")).not.toBeInTheDocument()
+    );
+    expect(api.delete).not.toHaveBeenCalled();
+  });
+
+  it("with no replacement LLM available the dialog blocks deletion", async () => {
+    llmsResp = [LLMS[1]]; // only "claude" exists
+    usageResp = { count: 1, projects: [{ id: 10, name: "proj-a", fields: ["llm"] }] };
+    const user = userEvent.setup();
+    await renderList();
+
+    await clickDeleteOnFirstRow(user);
+
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("llms.reassign.noReplacement")).toBeInTheDocument();
+    expect(within(dialog).getByRole("button", { name: "llms.reassign.confirm" })).toBeDisabled();
+    expect(api.delete).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/views/sessions/login/JwtLogin.jsx
+++ b/frontend/src/app/views/sessions/login/JwtLogin.jsx
@@ -108,7 +108,9 @@ const Orb = styled("div")(({ color, size, top, left, anim }) => ({
   pointerEvents: "none",
 }));
 
-const GlassCard = styled(Box)(({ shaking }) => ({
+const GlassCard = styled(Box, {
+  shouldForwardProp: (prop) => prop !== "shaking",
+})(({ shaking }) => ({
   position: "relative",
   zIndex: 2,
   width: "100%",

--- a/frontend/src/app/views/sessions/login/JwtLogin.test.jsx
+++ b/frontend/src/app/views/sessions/login/JwtLogin.test.jsx
@@ -1,0 +1,157 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import JwtLogin from "./JwtLogin";
+import useAuth from "app/hooks/useAuth";
+import { usePlatformCapabilities } from "app/contexts/PlatformContext";
+
+jest.mock("app/hooks/useAuth", () => jest.fn());
+jest.mock("app/contexts/PlatformContext", () => ({ usePlatformCapabilities: jest.fn() }));
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (k, p) => (p && p.provider ? `${k}:${p.provider}` : k),
+  }),
+}));
+
+const login = jest.fn();
+const verifyTotp = jest.fn();
+
+const renderLogin = () =>
+  render(
+    <MemoryRouter>
+      <JwtLogin />
+    </MemoryRouter>
+  );
+
+// The page assigns window.location.href on success — swap in a plain object.
+let locationMock;
+beforeEach(() => {
+  jest.clearAllMocks();
+  sessionStorage.clear();
+  useAuth.mockReturnValue({ login, verifyTotp });
+  usePlatformCapabilities.mockReturnValue({
+    platformCapabilities: { sso: [], sso_provider_names: {}, auth_disable_local: false, app_name: "RESTai" },
+  });
+  locationMock = { href: "", pathname: "/admin/login" };
+  delete window.location;
+  window.location = locationMock;
+});
+
+const originalLocation = window.location;
+afterAll(() => {
+  window.location = originalLocation;
+});
+
+async function fillAndReveal(user) {
+  await user.type(screen.getByLabelText("sessions.username"), "alice");
+  // First submit only reveals the password step.
+  await user.click(screen.getByRole("button", { name: "common.next" }));
+  await user.type(screen.getByLabelText("sessions.password"), "s3cret");
+}
+
+describe("JwtLogin", () => {
+  it("reveals the password step on first submit (progressive disclosure)", async () => {
+    const user = userEvent.setup();
+    renderLogin();
+    expect(screen.getByRole("button", { name: "common.next" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "common.next" }));
+    expect(screen.getByRole("button", { name: "sessions.signInAction" })).toBeInTheDocument();
+    expect(login).not.toHaveBeenCalled();
+  });
+
+  it("shows the session-expired banner once and clears the flag", async () => {
+    sessionStorage.setItem("session_expired", "1");
+    renderLogin();
+    expect(await screen.findByText(/session has expired/i)).toBeInTheDocument();
+    expect(sessionStorage.getItem("session_expired")).toBeNull();
+  });
+
+  it("logs in and redirects to /admin", async () => {
+    const user = userEvent.setup();
+    login.mockResolvedValue({ requires_totp: false });
+    renderLogin();
+
+    await fillAndReveal(user);
+    await user.click(screen.getByRole("button", { name: "sessions.signInAction" }));
+
+    await waitFor(() => expect(login).toHaveBeenCalledWith("alice", "s3cret"));
+    expect(locationMock.href).toBe("/admin");
+  });
+
+  it("surfaces login failures inline without redirecting", async () => {
+    const user = userEvent.setup();
+    login.mockRejectedValue(new Error("Bad credentials"));
+    renderLogin();
+
+    await fillAndReveal(user);
+    await user.click(screen.getByRole("button", { name: "sessions.signInAction" }));
+
+    expect(await screen.findByText("Bad credentials")).toBeInTheDocument();
+    expect(locationMock.href).toBe("");
+  });
+
+  it("switches to the TOTP step when 2FA is required, then verifies and redirects", async () => {
+    const user = userEvent.setup();
+    login.mockResolvedValue({ requires_totp: true, totp_token: "tt" });
+    verifyTotp.mockResolvedValue();
+    renderLogin();
+
+    await fillAndReveal(user);
+    await user.click(screen.getByRole("button", { name: "sessions.signInAction" }));
+
+    expect(await screen.findByText("sessions.totpTitle")).toBeInTheDocument();
+    await user.type(screen.getByLabelText("sessions.totpCodeLabel"), "123456");
+    await user.click(screen.getByRole("button", { name: "sessions.totpVerify" }));
+
+    await waitFor(() => expect(verifyTotp).toHaveBeenCalledWith("tt", "123456"));
+    expect(locationMock.href).toBe("/admin");
+  });
+
+  it("shows TOTP errors and supports the recovery-code toggle and back button", async () => {
+    const user = userEvent.setup();
+    login.mockResolvedValue({ requires_totp: true, totp_token: "tt" });
+    verifyTotp.mockRejectedValue(new Error("Invalid code."));
+    renderLogin();
+
+    await fillAndReveal(user);
+    await user.click(screen.getByRole("button", { name: "sessions.signInAction" }));
+    await screen.findByText("sessions.totpTitle");
+
+    await user.type(screen.getByLabelText("sessions.totpCodeLabel"), "000000");
+    await user.click(screen.getByRole("button", { name: "sessions.totpVerify" }));
+    expect(await screen.findByText("Invalid code.")).toBeInTheDocument();
+
+    // Toggle to recovery-code entry…
+    await user.click(screen.getByRole("button", { name: "sessions.totpRecoveryToggle" }));
+    expect(screen.getByPlaceholderText("abcd1234")).toBeInTheDocument();
+
+    // …and back to the credentials step.
+    await user.click(screen.getByRole("button", { name: "common.back" }));
+    expect(screen.getByRole("button", { name: "common.next" })).toBeInTheDocument();
+  });
+
+  it("renders SSO buttons and starts the provider flow on click", async () => {
+    const user = userEvent.setup();
+    usePlatformCapabilities.mockReturnValue({
+      platformCapabilities: {
+        sso: ["google", "github"],
+        sso_provider_names: { google: "Google" },
+        auth_disable_local: false,
+      },
+    });
+    renderLogin();
+
+    await user.click(screen.getByRole("button", { name: /google/i }));
+    expect(locationMock.href).toBe("/oauth/google/login");
+  });
+
+  it("hides the local form entirely when auth_disable_local is set", () => {
+    usePlatformCapabilities.mockReturnValue({
+      platformCapabilities: { sso: ["oidc"], sso_provider_names: {}, auth_disable_local: true },
+    });
+    renderLogin();
+    expect(screen.queryByLabelText("sessions.username")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /oidc/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/views/teams/MemberBudgetDialog.test.jsx
+++ b/frontend/src/app/views/teams/MemberBudgetDialog.test.jsx
@@ -1,0 +1,104 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import MemberBudgetDialog from "./MemberBudgetDialog";
+import api from "app/utils/api";
+import { toast } from "react-toastify";
+
+jest.mock("app/utils/api", () => ({ patch: jest.fn() }));
+jest.mock("react-toastify", () => ({ toast: { success: jest.fn(), error: jest.fn() } }));
+jest.mock("react-i18next", () => ({ useTranslation: () => ({ t: (k) => k }) }));
+jest.mock("app/hooks/useAuth", () => jest.fn());
+import useAuth from "app/hooks/useAuth";
+
+const baseMember = { user_id: 7, username: "bob", budget: 100, spending: 80 };
+
+const renderDialog = (over = {}) => {
+  const props = {
+    open: true,
+    onClose: jest.fn(),
+    teamId: 3,
+    member: baseMember,
+    onSaved: jest.fn(),
+    ...over,
+  };
+  render(<MemberBudgetDialog {...props} />);
+  return props;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useAuth.mockReturnValue({ user: { token: "tok", username: "admin" } });
+  api.patch.mockResolvedValue({ budget: 50 });
+});
+
+describe("MemberBudgetDialog", () => {
+  it("renders nothing without a member", () => {
+    const { container } = render(
+      <MemberBudgetDialog open onClose={() => {}} teamId={3} member={null} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the spend-vs-cap usage bar with the computed percentage", () => {
+    renderDialog();
+    expect(screen.getByText("$80.00 / $100.00 (80%)")).toBeInTheDocument();
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "80");
+  });
+
+  it("caps the displayed percentage at 100", () => {
+    renderDialog({ member: { ...baseMember, spending: 250 } });
+    expect(screen.getByText("$250.00 / $100.00 (100%)")).toBeInTheDocument();
+  });
+
+  it("omits the usage bar when the member has no cap", () => {
+    renderDialog({ member: { ...baseMember, budget: null } });
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+  });
+
+  it("saves the entered cap and fires callbacks", async () => {
+    const user = userEvent.setup();
+    const props = renderDialog();
+
+    const input = screen.getByLabelText("teams.budget.capInput");
+    await user.clear(input);
+    await user.type(input, "50");
+    await user.click(screen.getByRole("button", { name: "common.save" }));
+
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith(
+        "/teams/3/members/bob/budget",
+        { budget: 50 },
+        "tok"
+      )
+    );
+    expect(toast.success).toHaveBeenCalledWith("teams.budget.saved", expect.anything());
+    expect(props.onSaved).toHaveBeenCalledWith({ budget: 50 });
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it("Clear sends budget=-1 (unlimited)", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(screen.getByRole("button", { name: "teams.budget.clear" }));
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith(
+        "/teams/3/members/bob/budget",
+        { budget: -1 },
+        "tok"
+      )
+    );
+    expect(toast.success).toHaveBeenCalledWith("teams.budget.cleared", expect.anything());
+  });
+
+  it("treats a blank or non-positive value as clearing the cap", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.clear(screen.getByLabelText("teams.budget.capInput"));
+    await user.click(screen.getByRole("button", { name: "common.save" }));
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith(expect.any(String), { budget: -1 }, "tok")
+    );
+  });
+});

--- a/frontend/src/app/views/teams/PaymentCheckoutDialog.test.jsx
+++ b/frontend/src/app/views/teams/PaymentCheckoutDialog.test.jsx
@@ -1,0 +1,104 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import PaymentCheckoutDialog from "./PaymentCheckoutDialog";
+import api from "app/utils/api";
+import useAuth from "app/hooks/useAuth";
+
+jest.mock("app/utils/api", () => ({ post: jest.fn() }));
+jest.mock("react-i18next", () => ({ useTranslation: () => ({ t: (k) => k }) }));
+jest.mock("app/hooks/useAuth", () => jest.fn());
+
+let locationMock;
+const renderDialog = (over = {}) => {
+  const props = {
+    open: true,
+    onClose: jest.fn(),
+    teamId: 4,
+    providers: ["stripe"],
+    autoRechargeProviders: [],
+    ...over,
+  };
+  render(<PaymentCheckoutDialog {...props} />);
+  return props;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useAuth.mockReturnValue({ user: { token: "tok" } });
+  api.post.mockResolvedValue({ redirect_url: "https://pay.example/session" });
+  locationMock = { href: "" };
+  delete window.location;
+  window.location = locationMock;
+});
+
+describe("PaymentCheckoutDialog", () => {
+  it("disables Continue until a positive amount is entered", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    const cont = screen.getByRole("button", { name: "teams.payment.continue" });
+    expect(cont).toBeDisabled();
+    await user.type(screen.getByLabelText("teams.payment.amount"), "20");
+    expect(cont).toBeEnabled();
+  });
+
+  it("hides the provider picker with a single provider", () => {
+    renderDialog({ providers: ["stripe"] });
+    expect(screen.queryByText("teams.payment.provider")).not.toBeInTheDocument();
+  });
+
+  it("lets the user pick between providers and posts the selection", async () => {
+    const user = userEvent.setup();
+    renderDialog({ providers: ["stripe", "paypal"] });
+
+    await user.type(screen.getByLabelText("teams.payment.amount"), "20");
+    await user.click(screen.getByRole("radio", { name: "PayPal" }));
+    await user.click(screen.getByRole("button", { name: "teams.payment.continue" }));
+
+    await waitFor(() =>
+      expect(api.post).toHaveBeenCalledWith(
+        "/teams/4/balance/checkout",
+        { amount: 20, provider: "paypal", save_method: false },
+        "tok"
+      )
+    );
+  });
+
+  it("offers save-card only for auto-recharge-capable providers and sends the flag", async () => {
+    const user = userEvent.setup();
+    renderDialog({ providers: ["stripe"], autoRechargeProviders: ["stripe"] });
+
+    await user.type(screen.getByLabelText("teams.payment.amount"), "15");
+    await user.click(screen.getByRole("checkbox"));
+    await user.click(screen.getByRole("button", { name: "teams.payment.continue" }));
+
+    await waitFor(() =>
+      expect(api.post).toHaveBeenCalledWith(
+        expect.any(String),
+        { amount: 15, provider: "stripe", save_method: true },
+        "tok"
+      )
+    );
+  });
+
+  it("hands the browser off to the hosted checkout page", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByLabelText("teams.payment.amount"), "20");
+    await user.click(screen.getByRole("button", { name: "teams.payment.continue" }));
+    await waitFor(() => expect(locationMock.href).toBe("https://pay.example/session"));
+  });
+
+  it("recovers when the checkout response has no redirect", async () => {
+    api.post.mockResolvedValue({});
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByLabelText("teams.payment.amount"), "20");
+    const cont = screen.getByRole("button", { name: "teams.payment.continue" });
+    await user.click(cont);
+    await waitFor(() => expect(cont).toBeEnabled());
+    expect(locationMock.href).toBe("");
+  });
+});

--- a/frontend/src/app/views/teams/TeamWallet.test.jsx
+++ b/frontend/src/app/views/teams/TeamWallet.test.jsx
@@ -1,0 +1,239 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TeamWallet from "./TeamWallet";
+import api from "app/utils/api";
+import { toast } from "react-toastify";
+
+jest.mock("app/utils/api", () => ({
+  get: jest.fn(),
+  post: jest.fn(),
+  patch: jest.fn(),
+  put: jest.fn(),
+  delete: jest.fn(),
+}));
+jest.mock("react-toastify", () => ({
+  toast: { success: jest.fn(), error: jest.fn(), info: jest.fn() },
+}));
+jest.mock("react-i18next", () => ({ useTranslation: () => ({ t: (k) => k }) }));
+jest.mock("app/hooks/useAuth", () => jest.fn());
+import useAuth from "app/hooks/useAuth";
+
+const mockNavigate = jest.fn();
+let mockSearch = "";
+jest.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+  useParams: () => ({ id: "3" }),
+  useSearchParams: () => [new URLSearchParams(mockSearch), jest.fn()],
+}));
+
+// mui-datatables is heavy under jsdom; stub it to a div that dumps its
+// row data so ledger assertions stay possible.
+jest.mock("mui-datatables", () => ({
+  __esModule: true,
+  default: (props) => {
+    const React = require("react");
+    return React.createElement(
+      "div",
+      { "data-testid": "ledger-table" },
+      JSON.stringify(props.data)
+    );
+  },
+}));
+
+const TEAM = { id: 3, name: "acme", balance: 42 };
+const LEDGER = {
+  total: 1,
+  transactions: [
+    {
+      created_at: "2026-01-01T00:00:00Z",
+      kind: "topup",
+      amount: 10,
+      balance_after: 52,
+      actor_username: "walletadmin",
+      description: "seed money",
+    },
+  ],
+};
+const PAYCFG_OFF = {
+  payments_enabled: false,
+  providers: [],
+  auto_recharge_providers: [],
+  saved_method: null,
+  auto_recharge_enabled: false,
+};
+
+let teamResp;
+let ledgerResp;
+let payResp;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSearch = "";
+  useAuth.mockReturnValue({ user: { token: "tok", username: "admin", is_admin: true } });
+  teamResp = () => Promise.resolve(TEAM);
+  ledgerResp = () => Promise.resolve(LEDGER);
+  payResp = () => Promise.resolve(PAYCFG_OFF);
+  api.get.mockImplementation((path) => {
+    if (path === "/teams/3") return teamResp();
+    if (path.startsWith("/teams/3/balance/transactions")) return ledgerResp();
+    if (path === "/teams/3/payment") return payResp();
+    return Promise.resolve({});
+  });
+  api.put.mockResolvedValue(PAYCFG_OFF);
+  api.post.mockResolvedValue({});
+  api.delete.mockResolvedValue(PAYCFG_OFF);
+  window.confirm = jest.fn(() => true);
+});
+
+const renderWallet = async () => {
+  render(<TeamWallet />);
+  await screen.findByText("acme");
+};
+
+describe("TeamWallet", () => {
+  it("shows a spinner while the team is loading", () => {
+    api.get.mockImplementation(() => new Promise(() => {}));
+    render(<TeamWallet />);
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+  });
+
+  it("shows the forbidden message on 403 with a back link to the team", async () => {
+    teamResp = () => Promise.reject({ status: 403 });
+    const user = userEvent.setup();
+    render(<TeamWallet />);
+
+    expect(await screen.findByText("teams.analytics.forbidden")).toBeInTheDocument();
+    await user.click(screen.getByText("teams.analytics.backToTeam"));
+    expect(mockNavigate).toHaveBeenCalledWith("/team/3");
+  });
+
+  it("renders the wallet with an available balance and the fetched ledger", async () => {
+    await renderWallet();
+    expect(screen.getByText("teams.balance.available")).toBeInTheDocument();
+    expect(api.get).toHaveBeenCalledWith(
+      "/teams/3/balance/transactions?start=0&end=50",
+      "tok",
+      { silent: true }
+    );
+    const table = await screen.findByTestId("ledger-table");
+    await waitFor(() => {
+      expect(table).toHaveTextContent("topup");
+      expect(table).toHaveTextContent("walletadmin");
+      expect(table).toHaveTextContent("seed money");
+    });
+  });
+
+  it("shows the depleted badge when the balance is zero or below", async () => {
+    teamResp = () => Promise.resolve({ ...TEAM, balance: 0 });
+    render(<TeamWallet />);
+    expect(await screen.findByText("teams.balance.depleted")).toBeInTheDocument();
+  });
+
+  it("shows Add Funds only when payments are enabled with providers", async () => {
+    await renderWallet();
+    expect(screen.queryByRole("button", { name: "teams.payment.addFunds" })).not.toBeInTheDocument();
+  });
+
+  it("admin can open the top-up dialog; non-admin has no top-up action", async () => {
+    payResp = () => Promise.resolve({ ...PAYCFG_OFF, payments_enabled: true, providers: ["stripe"] });
+    const user = userEvent.setup();
+    await renderWallet();
+
+    expect(await screen.findByRole("button", { name: "teams.payment.addFunds" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "teams.balance.topUp" }));
+    expect(await screen.findByLabelText("teams.balance.addAmount")).toBeInTheDocument();
+  });
+
+  it("hides the admin top-up action from non-admins", async () => {
+    useAuth.mockReturnValue({ user: { token: "tok", username: "joe", is_admin: false } });
+    await renderWallet();
+    expect(screen.queryByRole("button", { name: "teams.balance.topUp" })).not.toBeInTheDocument();
+  });
+
+  it("offers card setup when auto-recharge is available but no card is saved", async () => {
+    payResp = () => Promise.resolve({ ...PAYCFG_OFF, auto_recharge_providers: ["stripe"] });
+    const user = userEvent.setup();
+    await renderWallet();
+
+    await user.click(await screen.findByRole("button", { name: "teams.payment.saveACard" }));
+    await waitFor(() =>
+      expect(api.post).toHaveBeenCalledWith("/teams/3/payment/setup?provider=stripe", {}, "tok")
+    );
+  });
+
+  it("saved card: toggling the switch saves auto-recharge enablement", async () => {
+    payResp = () =>
+      Promise.resolve({
+        ...PAYCFG_OFF,
+        auto_recharge_providers: ["stripe"],
+        saved_method: { brand: "visa", last4: "4242" },
+        auto_recharge_enabled: false,
+      });
+    const user = userEvent.setup();
+    await renderWallet();
+
+    expect(await screen.findByText("visa •••• 4242")).toBeInTheDocument();
+    await user.click(screen.getByRole("checkbox"));
+    await waitFor(() =>
+      expect(api.put).toHaveBeenCalledWith(
+        "/teams/3/payment/auto-recharge",
+        { enabled: true, threshold: null, amount: null },
+        "tok"
+      )
+    );
+    expect(toast.success).toHaveBeenCalledWith("teams.payment.autoRechargeSaved", expect.anything());
+  });
+
+  it("saved card: saving threshold/amount sends the parsed numbers", async () => {
+    payResp = () =>
+      Promise.resolve({
+        ...PAYCFG_OFF,
+        auto_recharge_providers: ["stripe"],
+        saved_method: { brand: "visa", last4: "4242" },
+        auto_recharge_enabled: true,
+      });
+    const user = userEvent.setup();
+    await renderWallet();
+
+    await user.type(await screen.findByLabelText("teams.payment.threshold"), "5");
+    await user.type(screen.getByLabelText("teams.payment.rechargeAmount"), "20");
+    await user.click(screen.getByRole("button", { name: "common.save" }));
+
+    await waitFor(() =>
+      expect(api.put).toHaveBeenCalledWith(
+        "/teams/3/payment/auto-recharge",
+        { enabled: true, threshold: 5, amount: 20 },
+        "tok"
+      )
+    );
+  });
+
+  it("saved card: removing the payment method confirms then deletes", async () => {
+    payResp = () =>
+      Promise.resolve({
+        ...PAYCFG_OFF,
+        auto_recharge_providers: ["stripe"],
+        saved_method: { brand: "visa", last4: "4242" },
+      });
+    const user = userEvent.setup();
+    await renderWallet();
+
+    await user.click(await screen.findByRole("button", { name: "teams.payment.removeMethod" }));
+
+    expect(window.confirm).toHaveBeenCalledWith("teams.payment.removeMethodConfirm");
+    await waitFor(() =>
+      expect(api.delete).toHaveBeenCalledWith("/teams/3/payment/method", "tok")
+    );
+    expect(toast.success).toHaveBeenCalledWith("teams.payment.methodRemoved", expect.anything());
+  });
+
+  it("handles the ?payment=success provider return: toast + URL cleanup", async () => {
+    mockSearch = "payment=success";
+    render(<TeamWallet />);
+
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith("teams.payment.success", expect.anything())
+    );
+    expect(mockNavigate).toHaveBeenCalledWith("/team/3/wallet", { replace: true });
+  });
+});

--- a/frontend/src/app/views/teams/Teams.test.jsx
+++ b/frontend/src/app/views/teams/Teams.test.jsx
@@ -1,0 +1,137 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Teams from "./Teams";
+import api from "app/utils/api";
+import { toast } from "react-toastify";
+
+jest.mock("app/utils/api", () => ({
+  get: jest.fn(),
+  post: jest.fn(),
+  patch: jest.fn(),
+  delete: jest.fn(),
+}));
+jest.mock("react-toastify", () => ({ toast: { success: jest.fn(), error: jest.fn() } }));
+jest.mock("react-i18next", () => ({ useTranslation: () => ({ t: (k) => k }) }));
+jest.mock("app/hooks/useAuth", () => jest.fn());
+import useAuth from "app/hooks/useAuth";
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+// Default sort is id desc, so row order is: beta (id 2), alpha (id 1).
+const TEAMS = [
+  {
+    id: 1,
+    name: "alpha",
+    description: "first team",
+    users: [{ username: "admin" }, { username: "bob" }],
+    projects: [{ id: 1 }],
+    admins: [],
+  },
+  {
+    id: 2,
+    name: "beta",
+    description: "",
+    users: [{ username: "bob" }],
+    projects: [],
+    admins: [{ username: "admin" }],
+  },
+];
+
+let teamsResp;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useAuth.mockReturnValue({ user: { token: "tok", username: "admin", is_admin: true } });
+  teamsResp = { teams: TEAMS };
+  api.get.mockImplementation(() => Promise.resolve(teamsResp));
+  api.delete.mockResolvedValue({});
+  window.confirm = jest.fn(() => true);
+});
+
+const renderTeams = async () => {
+  render(<Teams />);
+  if ((teamsResp.teams || []).length) {
+    await screen.findByText(teamsResp.teams[0].name);
+  } else {
+    await screen.findByText("teams.emptyTitle");
+  }
+};
+
+describe("Teams list", () => {
+  it("fetches /teams and renders one row per team", async () => {
+    await renderTeams();
+    expect(api.get).toHaveBeenCalledWith("/teams", "tok");
+    expect(screen.getByText("alpha")).toBeInTheDocument();
+    expect(screen.getByText("beta")).toBeInTheDocument();
+    expect(screen.getByText("TEAM/0001")).toBeInTheDocument();
+    expect(screen.getByText("TEAM/0002")).toBeInTheDocument();
+    expect(screen.getByText("first team")).toBeInTheDocument();
+  });
+
+  it("platform admin sees the platform_admin role pill on every row and a New Team action", async () => {
+    await renderTeams();
+    expect(screen.getAllByText("teams.role.platformAdmin")).toHaveLength(2);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "teams.new" }));
+    expect(mockNavigate).toHaveBeenCalledWith("/teams/new");
+  });
+
+  it("non-admin sees team_admin/member roles and no New Team button or delete action", async () => {
+    useAuth.mockReturnValue({ user: { token: "tok", username: "admin", is_admin: false } });
+    await renderTeams();
+    // admin of beta, plain member of alpha
+    expect(screen.getByText("teams.role.teamAdmin")).toBeInTheDocument();
+    expect(screen.getByText("teams.role.member")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "teams.new" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "teams.actions.delete" })).not.toBeInTheDocument();
+    // members can't edit
+    expect(screen.getAllByRole("button", { name: "teams.actions.edit" })).toHaveLength(1);
+  });
+
+  it("clicking a row navigates to the team page", async () => {
+    const user = userEvent.setup();
+    await renderTeams();
+    await user.click(screen.getByText("beta"));
+    expect(mockNavigate).toHaveBeenCalledWith("/team/2");
+  });
+
+  it("view action navigates to the team page", async () => {
+    const user = userEvent.setup();
+    await renderTeams();
+    // first row is beta (id 2)
+    await user.click(screen.getAllByRole("button", { name: "teams.actions.view" })[0]);
+    expect(mockNavigate).toHaveBeenCalledWith("/team/2");
+  });
+
+  it("delete confirms, calls the API and refetches", async () => {
+    const user = userEvent.setup();
+    await renderTeams();
+
+    await user.click(screen.getAllByRole("button", { name: "teams.actions.delete" })[0]);
+
+    expect(window.confirm).toHaveBeenCalledWith("teams.deleteConfirm");
+    await waitFor(() => expect(api.delete).toHaveBeenCalledWith("/teams/2", "tok"));
+    expect(toast.success).toHaveBeenCalledWith("teams.deleted");
+    await waitFor(() => expect(api.get.mock.calls.filter(([p]) => p === "/teams")).toHaveLength(2));
+  });
+
+  it("delete aborted by confirm does not call the API", async () => {
+    window.confirm = jest.fn(() => false);
+    const user = userEvent.setup();
+    await renderTeams();
+
+    await user.click(screen.getAllByRole("button", { name: "teams.actions.delete" })[0]);
+
+    expect(api.delete).not.toHaveBeenCalled();
+  });
+
+  it("renders the empty state when there are no teams", async () => {
+    teamsResp = { teams: [] };
+    await renderTeams();
+    expect(screen.getByText("teams.emptyTitle")).toBeInTheDocument();
+    expect(screen.getByText("teams.emptyMessage")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/views/teams/TopUpBalanceDialog.test.jsx
+++ b/frontend/src/app/views/teams/TopUpBalanceDialog.test.jsx
@@ -1,0 +1,72 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TopUpBalanceDialog from "./TopUpBalanceDialog";
+import api from "app/utils/api";
+import { toast } from "react-toastify";
+
+jest.mock("app/utils/api", () => ({ post: jest.fn() }));
+jest.mock("react-toastify", () => ({ toast: { success: jest.fn(), error: jest.fn() } }));
+jest.mock("react-i18next", () => ({ useTranslation: () => ({ t: (k) => k }) }));
+jest.mock("app/hooks/useAuth", () => jest.fn());
+import useAuth from "app/hooks/useAuth";
+
+const renderDialog = (over = {}) => {
+  const props = {
+    open: true,
+    onClose: jest.fn(),
+    teamId: 9,
+    current: 25,
+    onSaved: jest.fn(),
+    ...over,
+  };
+  render(<TopUpBalanceDialog {...props} />);
+  return props;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useAuth.mockReturnValue({ user: { token: "tok" } });
+  api.post.mockResolvedValue({ id: 9, balance: 75 });
+});
+
+describe("TopUpBalanceDialog", () => {
+  it("disables the top-up button until a positive amount is entered", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    const button = screen.getByRole("button", { name: "teams.balance.topUp" });
+    expect(button).toBeDisabled();
+
+    await user.type(screen.getByLabelText("teams.balance.addAmount"), "50");
+    expect(button).toBeEnabled();
+  });
+
+  it("previews the new balance as current + amount", async () => {
+    const user = userEvent.setup();
+    renderDialog({ current: 25 });
+
+    expect(screen.queryByText("teams.balance.newBalance")).not.toBeInTheDocument();
+    await user.type(screen.getByLabelText("teams.balance.addAmount"), "50");
+    expect(screen.getByText("teams.balance.newBalance")).toBeInTheDocument();
+  });
+
+  it("posts the top-up and fires callbacks", async () => {
+    const user = userEvent.setup();
+    const props = renderDialog();
+
+    await user.type(screen.getByLabelText("teams.balance.addAmount"), "50");
+    await user.click(screen.getByRole("button", { name: "teams.balance.topUp" }));
+
+    await waitFor(() =>
+      expect(api.post).toHaveBeenCalledWith("/teams/9/balance/topup", { amount: 50 }, "tok")
+    );
+    expect(props.onSaved).toHaveBeenCalledWith({ id: 9, balance: 75 });
+    expect(props.onClose).toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it("shows the wallet explainer when the team has no balance yet", () => {
+    renderDialog({ current: null });
+    expect(screen.getByText("teams.balance.walletHelp")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/views/users/components/ApiKeys.test.jsx
+++ b/frontend/src/app/views/users/components/ApiKeys.test.jsx
@@ -1,0 +1,279 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ApiKeys from "./ApiKeys";
+import api from "app/utils/api";
+import { toast } from "react-toastify";
+import useAuth from "app/hooks/useAuth";
+
+jest.mock("app/utils/api", () => ({
+  get: jest.fn(),
+  post: jest.fn(),
+  patch: jest.fn(),
+  delete: jest.fn(),
+}));
+jest.mock("react-toastify", () => ({ toast: { success: jest.fn(), error: jest.fn() } }));
+// Interpolated keys render as "key|value1|value2" so assertions can see the params.
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (k, p) => (p ? `${k}|${Object.values(p).join("|")}` : k),
+  }),
+}));
+jest.mock("app/hooks/useAuth", () => jest.fn());
+
+const target = {
+  username: "bob",
+  teams: [
+    { id: 1, name: "Team A" },
+    { id: 2, name: "Team B" },
+  ],
+};
+
+const PROJECTS = {
+  projects: [
+    { id: 10, name: "proj-a", team_id: 1 },
+    { id: 11, name: "proj-b", team_id: 1 },
+    { id: 20, name: "proj-c", team_id: 2 },
+  ],
+};
+
+const KEYS = [
+  {
+    id: 1,
+    description: "ci key",
+    key_prefix: "sk-aaa",
+    team_id: 1,
+    read_only: true,
+    allowed_projects: [10, 11],
+    token_quota_monthly: 1000,
+    tokens_used_this_month: 800,
+    quota_reset_at: "2026-09-01T00:00:00Z",
+    created_at: "2026-07-01T00:00:00Z",
+  },
+  {
+    id: 2,
+    description: "",
+    key_prefix: "sk-bbb",
+    team_id: 2,
+    read_only: false,
+    allowed_projects: null,
+    token_quota_monthly: null,
+    tokens_used_this_month: 0,
+    created_at: "2026-07-02T00:00:00Z",
+  },
+];
+
+function mockGets({ keys = KEYS, projects = PROJECTS } = {}) {
+  api.get.mockImplementation((url) => {
+    if (url.includes("/apikeys")) return Promise.resolve(keys);
+    if (url === "/projects") return Promise.resolve(projects);
+    return Promise.reject(new Error("unexpected " + url));
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useAuth.mockReturnValue({ user: { token: "tok", username: "admin", is_admin: true } });
+  mockGets();
+  api.post.mockResolvedValue({ api_key: "sk-plaintext-123" });
+  api.patch.mockResolvedValue({});
+  api.delete.mockResolvedValue({});
+});
+
+describe("ApiKeys listing", () => {
+  it("shows the empty state when there are no keys", async () => {
+    mockGets({ keys: [] });
+    render(<ApiKeys user={target} />);
+
+    expect(await screen.findByText("users.apiKeys.noKeys")).toBeInTheDocument();
+    expect(api.get).toHaveBeenCalledWith("/users/bob/apikeys", "tok");
+    expect(api.get).toHaveBeenCalledWith("/projects", "tok");
+  });
+
+  it("renders scope chips, team names and quota usage per key", async () => {
+    render(<ApiKeys user={target} />);
+
+    expect(await screen.findByText("ci key")).toBeInTheDocument();
+    expect(screen.getByText("sk-aaa...")).toBeInTheDocument();
+    expect(screen.getByText("Team A")).toBeInTheDocument();
+    expect(screen.getByText("Team B")).toBeInTheDocument();
+
+    // Key 1: read-only, restricted to 2 projects, 800/1000 tokens used.
+    expect(screen.getByText("users.apiKeys.readOnly")).toBeInTheDocument();
+    expect(screen.getByText("users.apiKeys.allowedProjects|2")).toBeInTheDocument();
+    expect(screen.getByText("users.apiKeys.quotaTokens|800|1,000")).toBeInTheDocument();
+    expect(screen.getByText(/^users\.apiKeys\.quotaResets\|/)).toBeInTheDocument();
+
+    // Key 2: unrestricted, no quota.
+    expect(screen.getByText("users.apiKeys.allProjects")).toBeInTheDocument();
+    expect(screen.getByText("users.apiKeys.unlimited")).toBeInTheDocument();
+  });
+});
+
+describe("ApiKeys creation", () => {
+  it("requires a team, preselects the team's projects, and reveals the new key once", async () => {
+    const user = userEvent.setup();
+    render(<ApiKeys user={target} />);
+    await screen.findByText("ci key");
+
+    await user.click(screen.getByRole("button", { name: "users.apiKeys.createNew" }));
+    const dialog = await screen.findByRole("dialog");
+
+    // Create disabled until a team is chosen (key bills the team's budget).
+    const create = within(dialog).getByRole("button", { name: "common.create" });
+    expect(create).toBeDisabled();
+
+    await user.type(
+      within(dialog).getByLabelText(/users\.apiKeys\.descriptionOptional/),
+      "deploy key"
+    );
+
+    // Pick Team A → its two projects are auto-selected in the restrict field.
+    await user.click(within(dialog).getByLabelText(/users\.apiKeys\.team/));
+    await user.click(await screen.findByRole("option", { name: "Team A" }));
+    expect(within(dialog).getByText("proj-a")).toBeInTheDocument();
+    expect(within(dialog).getByText("proj-b")).toBeInTheDocument();
+    expect(create).toBeEnabled();
+
+    await user.click(create);
+
+    await waitFor(() =>
+      expect(api.post).toHaveBeenCalledWith(
+        "/users/bob/apikeys",
+        { description: "deploy key", team_id: 1, read_only: false, allowed_projects: [10, 11] },
+        "tok"
+      )
+    );
+
+    // Save-this-key dialog with the plaintext, copyable value.
+    expect(await screen.findByText("users.apiKeys.saveKeyWarn")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("sk-plaintext-123")).toBeInTheDocument();
+
+    const writeText = jest.fn();
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    await user.click(screen.getByTestId("ContentCopyIcon").closest("button"));
+    expect(writeText).toHaveBeenCalledWith("sk-plaintext-123");
+    expect(toast.success).toHaveBeenCalledWith("common.copied");
+  });
+
+  it("sends the read_only flag and drops deselected projects", async () => {
+    const user = userEvent.setup();
+    render(<ApiKeys user={target} />);
+    await screen.findByText("ci key");
+
+    await user.click(screen.getByRole("button", { name: "users.apiKeys.createNew" }));
+    const dialog = await screen.findByRole("dialog");
+
+    await user.click(within(dialog).getByLabelText(/users\.apiKeys\.team/));
+    await user.click(await screen.findByRole("option", { name: "Team A" }));
+
+    // Remove both preselected project chips → allowed_projects omitted (all projects).
+    for (const chip of ["proj-a", "proj-b"]) {
+      await user.click(
+        within(within(dialog).getByText(chip).closest(".MuiChip-root")).getByTestId("CancelIcon")
+      );
+    }
+    await user.click(within(dialog).getByRole("checkbox"));
+
+    await user.click(within(dialog).getByRole("button", { name: "common.create" }));
+
+    await waitFor(() =>
+      expect(api.post).toHaveBeenCalledWith(
+        "/users/bob/apikeys",
+        { description: "", team_id: 1, read_only: true },
+        "tok"
+      )
+    );
+  });
+});
+
+describe("ApiKeys quota dialog", () => {
+  it("saves a new monthly cap", async () => {
+    const user = userEvent.setup();
+    render(<ApiKeys user={target} />);
+    await screen.findByText("ci key");
+
+    await user.click(screen.getAllByTestId("EditIcon")[0].closest("button"));
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("users.apiKeys.quotaUsedThis|sk-aaa|800")).toBeInTheDocument();
+
+    const input = within(dialog).getByLabelText(/users\.apiKeys\.quotaInput/);
+    expect(input).toHaveValue(1000);
+    await user.clear(input);
+    await user.type(input, "5000");
+    await user.click(within(dialog).getByRole("button", { name: "common.save" }));
+
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith(
+        "/users/bob/apikeys/1",
+        { token_quota_monthly: 5000 },
+        "tok"
+      )
+    );
+    expect(toast.success).toHaveBeenCalledWith("users.apiKeys.quotaSaved", { position: "top-right" });
+  });
+
+  it("clears the cap when the field is emptied", async () => {
+    const user = userEvent.setup();
+    render(<ApiKeys user={target} />);
+    await screen.findByText("ci key");
+
+    await user.click(screen.getAllByTestId("EditIcon")[0].closest("button"));
+    const dialog = await screen.findByRole("dialog");
+    await user.clear(within(dialog).getByLabelText(/users\.apiKeys\.quotaInput/));
+    await user.click(within(dialog).getByRole("button", { name: "common.save" }));
+
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith(
+        "/users/bob/apikeys/1",
+        { token_quota_monthly: 0 },
+        "tok"
+      )
+    );
+  });
+
+  it("resets usage via the warning action", async () => {
+    const user = userEvent.setup();
+    render(<ApiKeys user={target} />);
+    await screen.findByText("ci key");
+
+    await user.click(screen.getAllByTestId("EditIcon")[0].closest("button"));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: "users.apiKeys.resetUsage" }));
+
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith("/users/bob/apikeys/1", { reset_usage: true }, "tok")
+    );
+    expect(toast.success).toHaveBeenCalledWith("users.apiKeys.usageReset", { position: "top-right" });
+  });
+});
+
+describe("ApiKeys deletion", () => {
+  it("deletes after confirmation and refetches", async () => {
+    const user = userEvent.setup();
+    jest.spyOn(window, "confirm").mockReturnValue(true);
+    render(<ApiKeys user={target} />);
+    await screen.findByText("ci key");
+    api.get.mockClear();
+
+    await user.click(screen.getAllByTestId("DeleteIcon")[0].closest("button"));
+
+    await waitFor(() =>
+      expect(api.delete).toHaveBeenCalledWith("/users/bob/apikeys/1", "tok")
+    );
+    expect(api.get).toHaveBeenCalledWith("/users/bob/apikeys", "tok");
+  });
+
+  it("does nothing when the confirm is dismissed", async () => {
+    const user = userEvent.setup();
+    jest.spyOn(window, "confirm").mockReturnValue(false);
+    render(<ApiKeys user={target} />);
+    await screen.findByText("ci key");
+
+    await user.click(screen.getAllByTestId("DeleteIcon")[0].closest("button"));
+
+    expect(api.delete).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/views/users/components/AvatarBadge.jsx
+++ b/frontend/src/app/views/users/components/AvatarBadge.jsx
@@ -1,6 +1,8 @@
 import { Badge, styled } from "@mui/material";
 
-const StyledBadge = styled(Badge)(({ theme, width, height }) => ({
+const StyledBadge = styled(Badge, {
+  shouldForwardProp: (prop) => prop !== "width" && prop !== "height",
+})(({ theme, width, height }) => ({
   "& .MuiBadge-badge": {
     width: width,
     height: height,

--- a/frontend/src/app/views/users/components/AvatarBadge.test.jsx
+++ b/frontend/src/app/views/users/components/AvatarBadge.test.jsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import AvatarBadge from "./AvatarBadge";
+
+describe("AvatarBadge", () => {
+  it("renders its children", () => {
+    render(
+      <AvatarBadge>
+        <img src="/me.png" alt="me" />
+      </AvatarBadge>
+    );
+    expect(screen.getByAltText("me")).toBeInTheDocument();
+  });
+
+  it("renders a circular-overlap badge element", () => {
+    const { container } = render(
+      <AvatarBadge variant="dot">
+        <span>kid</span>
+      </AvatarBadge>
+    );
+    const badge = container.querySelector(".MuiBadge-badge");
+    expect(badge).toBeInTheDocument();
+    expect(badge.className).toMatch(/MuiBadge-overlapCircular/);
+  });
+
+  it("shows badge content and passes extra props through", () => {
+    render(
+      <AvatarBadge badgeContent="7" color="success">
+        <span>kid</span>
+      </AvatarBadge>
+    );
+    expect(screen.getByText("7")).toBeInTheDocument();
+    expect(screen.getByText("7").className).toMatch(/MuiBadge-colorSuccess/);
+  });
+
+  it("sizes the badge from the width/height props", () => {
+    const { container } = render(
+      <AvatarBadge badgeContent="x" width={20} height={20}>
+        <span>kid</span>
+      </AvatarBadge>
+    );
+    expect(container.querySelector(".MuiBadge-badge")).toHaveStyle({
+      width: "20px",
+      height: "20px",
+    });
+  });
+});

--- a/frontend/src/app/views/users/components/BasicInformation.jsx
+++ b/frontend/src/app/views/users/components/BasicInformation.jsx
@@ -115,7 +115,7 @@ export default function BasicInformation({ user }) {
                   label={t("users.basic.authSso")}
                   variant="outlined"
                   onChange={handleChange}
-                  value={user.sso ?? ''}
+                  value={state.sso ?? ''}
                 />
               </Grid>
 

--- a/frontend/src/app/views/users/components/BasicInformation.test.jsx
+++ b/frontend/src/app/views/users/components/BasicInformation.test.jsx
@@ -1,0 +1,119 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import BasicInformation from "./BasicInformation";
+import api from "app/utils/api";
+import useAuth from "app/hooks/useAuth";
+import { applyLanguage } from "app/i18n";
+
+jest.mock("app/utils/api", () => ({ patch: jest.fn() }));
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k) => k, i18n: { language: "en" } }),
+}));
+jest.mock("app/hooks/useAuth", () => jest.fn());
+jest.mock("app/i18n", () => ({
+  SUPPORTED_LANGUAGES: [
+    { code: "en", label: "English", nativeLabel: "English" },
+    { code: "de", label: "German", nativeLabel: "Deutsch" },
+  ],
+  applyLanguage: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockNavigate,
+}));
+
+const renderIt = (target) =>
+  render(
+    <MemoryRouter>
+      <BasicInformation user={target} />
+    </MemoryRouter>
+  );
+
+let locationMock;
+beforeEach(() => {
+  jest.clearAllMocks();
+  useAuth.mockReturnValue({ user: { token: "tok", username: "admin", is_admin: true } });
+  api.patch.mockResolvedValue({});
+  locationMock = { href: "", pathname: "/admin/user/bob" };
+  delete window.location;
+  window.location = locationMock;
+});
+
+describe("BasicInformation rendering", () => {
+  it("shows admin-only switches when an admin views another user (no language, suspend visible)", () => {
+    renderIt({ username: "bob", is_admin: false });
+
+    expect(screen.getByText("users.fields.isAdmin")).toBeInTheDocument();
+    expect(screen.getByText("users.fields.isPrivate")).toBeInTheDocument();
+    expect(screen.getByText("users.basic.restricted")).toBeInTheDocument();
+    // Suspend only shows for admin viewing someone else.
+    expect(screen.getByRole("checkbox", { name: "suspended checkbox" })).toBeInTheDocument();
+    // Language editor is self-profile only.
+    expect(screen.queryByText("users.basic.language")).not.toBeInTheDocument();
+  });
+
+  it("hides all privileged switches from a plain non-admin user", () => {
+    useAuth.mockReturnValue({ user: { token: "tok", username: "carol", is_admin: false } });
+    renderIt({ username: "bob" });
+
+    expect(screen.queryByText("users.fields.isAdmin")).not.toBeInTheDocument();
+    expect(screen.queryByText("users.fields.isPrivate")).not.toBeInTheDocument();
+    expect(screen.queryByText("users.basic.restricted")).not.toBeInTheDocument();
+    expect(screen.queryByRole("checkbox", { name: "suspended checkbox" })).not.toBeInTheDocument();
+  });
+
+  it("hides the suspend switch on your own profile but shows the language picker", () => {
+    renderIt({ username: "admin", is_admin: true });
+
+    expect(screen.queryByRole("checkbox", { name: "suspended checkbox" })).not.toBeInTheDocument();
+    // Label + fieldset legend both carry the key.
+    expect(screen.getAllByText("users.basic.language").length).toBeGreaterThan(0);
+  });
+});
+
+describe("BasicInformation saving", () => {
+  it("patches only the changed flags and redirects to the profile", async () => {
+    const user = userEvent.setup();
+    renderIt({ username: "bob", is_admin: false, is_restricted: false });
+
+    await user.click(screen.getByRole("checkbox", { name: "restricted checkbox" }));
+    await user.click(screen.getByRole("button", { name: "users.basic.saveChanges" }));
+
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith("/users/bob", { is_restricted: true }, "tok")
+    );
+    expect(locationMock.href).toBe("/admin/user/bob");
+  });
+
+  it("saves a language change on the self profile and applies it locally", async () => {
+    const user = userEvent.setup();
+    renderIt({ username: "admin", is_admin: true, options: { language: "en" } });
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: "Deutsch" }));
+    await user.click(screen.getByRole("button", { name: "users.basic.saveChanges" }));
+
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith(
+        "/users/admin",
+        { options: { language: "de" } },
+        "tok"
+      )
+    );
+    expect(applyLanguage).toHaveBeenCalledWith("de");
+    expect(locationMock.href).toBe("/admin/user/admin");
+  });
+
+  it("cancel navigates back to the users list without patching", async () => {
+    const user = userEvent.setup();
+    renderIt({ username: "bob" });
+
+    await user.click(screen.getByRole("button", { name: "common.cancel" }));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/users");
+    expect(api.patch).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/views/users/components/BasicInformation.test.jsx
+++ b/frontend/src/app/views/users/components/BasicInformation.test.jsx
@@ -116,4 +116,20 @@ describe("BasicInformation saving", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/users");
     expect(api.patch).not.toHaveBeenCalled();
   });
+
+  it("SSO field is a working controlled input and PATCHes the typed value", async () => {
+    const user = userEvent.setup();
+    renderIt({ username: "bob", sso: "" });
+
+    // Regression: the field used to bind value to the immutable prop, so
+    // typing displayed nothing and only the last keystroke would be saved.
+    const sso = screen.getByLabelText("users.basic.authSso");
+    await user.type(sso, "google");
+    expect(sso).toHaveValue("google");
+
+    await user.click(screen.getByRole("button", { name: "users.basic.saveChanges" }));
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith("/users/bob", expect.objectContaining({ sso: "google" }), "tok")
+    );
+  });
 });

--- a/frontend/src/app/views/users/components/DeleteAccount.test.jsx
+++ b/frontend/src/app/views/users/components/DeleteAccount.test.jsx
@@ -1,0 +1,53 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import DeleteAccount from "./DeleteAccount";
+import api from "app/utils/api";
+import useAuth from "app/hooks/useAuth";
+
+jest.mock("app/utils/api", () => ({ delete: jest.fn() }));
+jest.mock("react-i18next", () => ({ useTranslation: () => ({ t: (k) => k }) }));
+jest.mock("app/hooks/useAuth", () => jest.fn());
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockNavigate,
+}));
+
+const renderIt = () =>
+  render(
+    <MemoryRouter>
+      <DeleteAccount user={{ username: "bob" }} />
+    </MemoryRouter>
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useAuth.mockReturnValue({ user: { token: "tok" } });
+  api.delete.mockResolvedValue(null);
+});
+
+describe("DeleteAccount", () => {
+  it("keeps the delete button disabled until the confirmation is checked", async () => {
+    const user = userEvent.setup();
+    renderIt();
+
+    const button = screen.getByRole("button", { name: "users.deleteAccount.delete" });
+    expect(button).toBeDisabled();
+
+    await user.click(screen.getByRole("checkbox"));
+    expect(button).toBeEnabled();
+  });
+
+  it("deletes the account and navigates to the users list", async () => {
+    const user = userEvent.setup();
+    renderIt();
+
+    await user.click(screen.getByRole("checkbox"));
+    await user.click(screen.getByRole("button", { name: "users.deleteAccount.delete" }));
+
+    await waitFor(() => expect(api.delete).toHaveBeenCalledWith("/users/bob", "tok"));
+    expect(mockNavigate).toHaveBeenCalledWith("/users");
+  });
+});

--- a/frontend/src/app/views/users/components/Password.test.jsx
+++ b/frontend/src/app/views/users/components/Password.test.jsx
@@ -1,0 +1,79 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Password from "./Password";
+import api from "app/utils/api";
+import { toast } from "react-toastify";
+import useAuth from "app/hooks/useAuth";
+
+jest.mock("app/utils/api", () => ({ get: jest.fn(), patch: jest.fn() }));
+jest.mock("react-toastify", () => ({ toast: { success: jest.fn(), error: jest.fn() } }));
+jest.mock("react-i18next", () => ({ useTranslation: () => ({ t: (k) => k }) }));
+jest.mock("app/hooks/useAuth", () => jest.fn());
+
+const target = { username: "bob" };
+
+let locationMock;
+beforeEach(() => {
+  jest.clearAllMocks();
+  useAuth.mockReturnValue({ user: { token: "tok", username: "admin" } });
+  api.get.mockResolvedValue({ enabled: false });
+  api.patch.mockResolvedValue({});
+  locationMock = { href: "", pathname: "/admin/user/bob" };
+  delete window.location;
+  window.location = locationMock;
+});
+
+async function fillPasswords(user, pw, confirm) {
+  await user.type(screen.getByLabelText("users.password.newPassword"), pw);
+  await user.type(screen.getByLabelText("users.password.confirmPassword"), confirm);
+}
+
+describe("Password", () => {
+  it("saves the new password and redirects to the profile", async () => {
+    const user = userEvent.setup();
+    render(<Password user={target} />);
+
+    await fillPasswords(user, "newpass1", "newpass1");
+    await user.click(screen.getByRole("button", { name: "users.password.saveChanges" }));
+
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith("/users/bob", { password: "newpass1" }, "tok")
+    );
+    expect(locationMock.href).toBe("/admin/user/bob");
+  });
+
+  it("rejects mismatched confirmation without calling the API", async () => {
+    const user = userEvent.setup();
+    render(<Password user={target} />);
+
+    await fillPasswords(user, "one", "two");
+    await user.click(screen.getByRole("button", { name: "users.password.saveChanges" }));
+
+    expect(toast.error).toHaveBeenCalledWith("users.password.mismatch");
+    expect(api.patch).not.toHaveBeenCalled();
+  });
+
+  it("requires the TOTP code when 2FA is enabled, and sends it with the change", async () => {
+    api.get.mockResolvedValue({ enabled: true });
+    const user = userEvent.setup();
+    render(<Password user={target} />);
+
+    // 2FA on → info alert + code field appear after the status fetch.
+    expect(await screen.findByText("users.password.twoFactorAlert")).toBeInTheDocument();
+
+    await fillPasswords(user, "newpass1", "newpass1");
+    await user.click(screen.getByRole("button", { name: "users.password.saveChanges" }));
+    expect(toast.error).toHaveBeenCalledWith("users.password.twoFactorRequired");
+    expect(api.patch).not.toHaveBeenCalled();
+
+    await user.type(screen.getByLabelText("users.password.twoFactorCode"), "123456");
+    await user.click(screen.getByRole("button", { name: "users.password.saveChanges" }));
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith(
+        "/users/bob",
+        { password: "newpass1", totp_code: "123456" },
+        "tok"
+      )
+    );
+  });
+});

--- a/frontend/src/app/views/users/components/Projects.jsx
+++ b/frontend/src/app/views/users/components/Projects.jsx
@@ -51,18 +51,12 @@ export default function Preferences({ user, projects }) {
     ...projectMap[p.id],
   }));
 
-  const diassoc = (project) => {
-    var updatedProjects = user.projects.filter((p) => p.id !== project.id);
-    user.projects = updatedProjects;
-    onSubmitHandler();
-  }
-
-  const onSubmitHandler = (event) => {
-    if (event)
-      event.preventDefault();
-
+  // Submit an explicit project list instead of mutating the `user` prop —
+  // the previous in-place push/filter only worked because the page hard
+  // redirects after the PATCH.
+  const submitProjects = (projectList) => {
     api.patch("/users/" + user.username, {
-      "projects": user.projects.map((p) => {
+      "projects": projectList.map((p) => {
         // Try to get name from the project object or from the projectMap
         const projectName = p.name || (projectMap[p.id] && projectMap[p.id].name);
         return projectName;
@@ -72,7 +66,10 @@ export default function Preferences({ user, projects }) {
         window.location.href = "/admin/user/" + user.username;
       })
       .catch(() => {});
+  }
 
+  const diassoc = (project) => {
+    submitProjects(user.projects.filter((p) => p.id !== project.id));
   }
 
   const handleChange = (event) => {
@@ -112,8 +109,7 @@ export default function Preferences({ user, projects }) {
               <Button type="submit" variant="contained" mt={1} onClick={() => { 
                 const selectedProject = projects.find(p => p.name === state.addproject);
                 if (selectedProject) {
-                  user.projects.push({ "name": selectedProject.name, "id": selectedProject.id }); 
-                  onSubmitHandler();
+                  submitProjects([...user.projects, { "name": selectedProject.name, "id": selectedProject.id }]);
                 }
               }}>
                 {t("users.userProjects.associate")}

--- a/frontend/src/app/views/users/components/Projects.test.jsx
+++ b/frontend/src/app/views/users/components/Projects.test.jsx
@@ -1,0 +1,92 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Projects from "./Projects";
+import api from "app/utils/api";
+import useAuth from "app/hooks/useAuth";
+
+jest.mock("app/utils/api", () => ({ patch: jest.fn() }));
+jest.mock("react-i18next", () => ({ useTranslation: () => ({ t: (k) => k }) }));
+jest.mock("app/hooks/useAuth", () => jest.fn());
+// boring-avatars is ESM-only ("type": "module") — CRA jest can't transform it.
+jest.mock("boring-avatars", () => () => null);
+
+const ALL_PROJECTS = [
+  { id: 1, name: "alpha", human_name: "Alpha Bot" },
+  { id: 2, name: "beta", human_name: "Beta Bot" },
+];
+
+const makeTarget = () => ({
+  username: "bob",
+  projects: [{ id: 1, name: "alpha" }],
+});
+
+let locationMock;
+beforeEach(() => {
+  jest.clearAllMocks();
+  useAuth.mockReturnValue({ user: { token: "tok", username: "admin", is_admin: true } });
+  api.patch.mockResolvedValue({});
+  locationMock = { href: "", pathname: "/admin/user/bob" };
+  delete window.location;
+  window.location = locationMock;
+});
+
+describe("Projects", () => {
+  it("lists the user's projects enriched from the global project list", () => {
+    render(<Projects user={makeTarget()} projects={ALL_PROJECTS} />);
+
+    expect(screen.getByText("users.userProjects.title")).toBeInTheDocument();
+    expect(screen.getByText("alpha")).toBeInTheDocument();
+    expect(screen.getByText("(ID: 1)")).toBeInTheDocument();
+    // human_name is lowercased for display.
+    expect(screen.getByText("alpha bot")).toBeInTheDocument();
+    // Not associated → not shown as a card.
+    expect(screen.queryByText("beta")).not.toBeInTheDocument();
+  });
+
+  it("hides associate/dissociate controls from non-admins", () => {
+    useAuth.mockReturnValue({ user: { token: "tok", username: "bob", is_admin: false } });
+    render(<Projects user={makeTarget()} projects={ALL_PROJECTS} />);
+
+    expect(screen.queryByRole("button", { name: "users.userProjects.associate" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "users.userProjects.dissociate" })).not.toBeInTheDocument();
+  });
+
+  it("associates a selected project and patches the full name list", async () => {
+    const user = userEvent.setup();
+    render(<Projects user={makeTarget()} projects={ALL_PROJECTS} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: "beta (ID: 2)" }));
+    await user.click(screen.getByRole("button", { name: "users.userProjects.associate" }));
+
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith(
+        "/users/bob",
+        { projects: ["alpha", "beta"] },
+        "tok"
+      )
+    );
+    expect(locationMock.href).toBe("/admin/user/bob");
+  });
+
+  it("does nothing when associate is clicked with no project selected", async () => {
+    const user = userEvent.setup();
+    render(<Projects user={makeTarget()} projects={ALL_PROJECTS} />);
+
+    await user.click(screen.getByRole("button", { name: "users.userProjects.associate" }));
+
+    expect(api.patch).not.toHaveBeenCalled();
+  });
+
+  it("dissociates a project and patches the remaining names", async () => {
+    const user = userEvent.setup();
+    render(<Projects user={makeTarget()} projects={ALL_PROJECTS} />);
+
+    await user.click(screen.getByRole("button", { name: "users.userProjects.dissociate" }));
+
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith("/users/bob", { projects: [] }, "tok")
+    );
+    expect(locationMock.href).toBe("/admin/user/bob");
+  });
+});

--- a/frontend/src/app/views/users/components/Projects.test.jsx
+++ b/frontend/src/app/views/users/components/Projects.test.jsx
@@ -89,4 +89,19 @@ describe("Projects", () => {
     );
     expect(locationMock.href).toBe("/admin/user/bob");
   });
+
+  it("never mutates the user prop when associating or dissociating", async () => {
+    const user = userEvent.setup();
+    const target = makeTarget();
+    const originalProjects = target.projects;
+    render(<Projects user={target} projects={ALL_PROJECTS} />);
+
+    await user.click(screen.getByRole("button", { name: "users.userProjects.dissociate" }));
+    await waitFor(() => expect(api.patch).toHaveBeenCalled());
+
+    // The prop object must be untouched — the PATCH payload is derived,
+    // not the result of an in-place filter/push on user.projects.
+    expect(target.projects).toBe(originalProjects);
+    expect(target.projects).toEqual([{ id: 1, name: "alpha" }]);
+  });
 });

--- a/frontend/src/app/views/users/components/Teams.test.jsx
+++ b/frontend/src/app/views/users/components/Teams.test.jsx
@@ -1,0 +1,92 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import Teams from "./Teams";
+import api from "app/utils/api";
+import useAuth from "app/hooks/useAuth";
+
+jest.mock("app/utils/api", () => ({ get: jest.fn() }));
+// Interpolated keys render as "key|value1|value2" so assertions can see the params.
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (k, p) => (p ? `${k}|${Object.values(p).join("|")}` : k),
+  }),
+}));
+jest.mock("app/hooks/useAuth", () => jest.fn());
+
+const renderIt = (target) =>
+  render(
+    <MemoryRouter>
+      <Teams user={target} />
+    </MemoryRouter>
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useAuth.mockReturnValue({ user: { token: "tok", username: "admin" } });
+});
+
+describe("Teams with the budget endpoint", () => {
+  it("renders capped, uncapped and depleted-wallet team cards", async () => {
+    api.get.mockResolvedValue({
+      teams: [
+        { team_id: 1, team_name: "Alpha", is_admin: true, budget: 100, spending: 80, team_balance: 12.5 },
+        { team_id: 2, team_name: "Beta", is_admin: false, budget: null, spending: 3.5, team_balance: 0 },
+      ],
+    });
+    renderIt({ username: "bob", teams: [{ id: 2, name: "Beta", description: "the beta team" }] });
+
+    expect(await screen.findByText("Alpha")).toBeInTheDocument();
+    expect(api.get).toHaveBeenCalledWith("/users/bob/team-budgets", "tok", { silent: true });
+
+    // Card count badge.
+    expect(screen.getByText("2")).toBeInTheDocument();
+
+    // Alpha: admin chip, 80/100 → 80%, remaining $20, wallet balance shown.
+    expect(screen.getByText("users.userTeams.admin")).toBeInTheDocument();
+    expect(screen.getByText("80%")).toBeInTheDocument();
+    expect(screen.getByText("users.userTeams.remaining|$20.00")).toBeInTheDocument();
+    expect(screen.getByText("users.userTeams.teamWallet|$12.50")).toBeInTheDocument();
+
+    // Beta: member chip, uncapped spend line, depleted wallet, description from profile.
+    expect(screen.getByText("users.userTeams.member")).toBeInTheDocument();
+    expect(screen.getByText(/users\.userTeams\.spentThisMonth\|\$3\.50/)).toBeInTheDocument();
+    expect(screen.getByText(/users\.userTeams\.uncapped/)).toBeInTheDocument();
+    expect(screen.getByText("teams.balance.depleted")).toBeInTheDocument();
+    expect(screen.getByText("the beta team")).toBeInTheDocument();
+
+    // Team name links to the team page.
+    expect(screen.getByRole("link", { name: "Alpha" })).toHaveAttribute("href", "/team/1");
+  });
+});
+
+describe("Teams fallback when the budget endpoint fails", () => {
+  it("builds cards from the profile team lists with admin flags", async () => {
+    api.get.mockRejectedValue(new Error("older backend"));
+    renderIt({
+      username: "bob",
+      teams: [
+        { id: 1, name: "Zulu" },
+        { id: 2, name: "Alpha" },
+      ],
+      admin_teams: [{ id: 2, name: "Alpha" }],
+    });
+
+    await waitFor(() => expect(api.get).toHaveBeenCalled());
+
+    // Sorted alphabetically: Alpha (admin) then Zulu (member).
+    const links = screen.getAllByRole("link");
+    expect(links.map((l) => l.textContent)).toEqual(["Alpha", "Zulu"]);
+    expect(screen.getByText("users.userTeams.admin")).toBeInTheDocument();
+    expect(screen.getByText("users.userTeams.member")).toBeInTheDocument();
+
+    // Fallback has no budget info → uncapped spend of $0.00 on both.
+    expect(screen.getAllByText(/users\.userTeams\.spentThisMonth\|\$0\.00/)).toHaveLength(2);
+  });
+
+  it("shows the empty state for a user with no teams", async () => {
+    api.get.mockResolvedValue({ teams: [] });
+    renderIt({ username: "bob", teams: [] });
+
+    expect(await screen.findByText("users.userTeams.noTeams")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/views/users/components/TwoFactorAuth.test.jsx
+++ b/frontend/src/app/views/users/components/TwoFactorAuth.test.jsx
@@ -1,0 +1,121 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TwoFactorAuth from "./TwoFactorAuth";
+import api from "app/utils/api";
+import { toast } from "react-toastify";
+import useAuth from "app/hooks/useAuth";
+
+jest.mock("app/utils/api", () => ({ get: jest.fn(), post: jest.fn() }));
+jest.mock("react-toastify", () => ({ toast: { success: jest.fn(), error: jest.fn() } }));
+jest.mock("react-i18next", () => ({ useTranslation: () => ({ t: (k) => k }) }));
+jest.mock("app/hooks/useAuth", () => jest.fn());
+
+const SETUP = {
+  secret: "BASE32SECRET",
+  provisioning_uri: "otpauth://totp/RESTai:bob?secret=BASE32SECRET",
+  recovery_codes: ["aaaa-1111", "bbbb-2222", "cccc-3333", "dddd-4444"],
+};
+
+const renderIt = (username = "bob") =>
+  render(<TwoFactorAuth user={{ username: "bob" }} />);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useAuth.mockReturnValue({ user: { token: "tok", username: "bob" } });
+  api.get.mockResolvedValue({ enabled: false, enforced: false });
+});
+
+describe("TwoFactorAuth setup flow", () => {
+  it("walks through setup: QR + secret + recovery codes, then enables", async () => {
+    const user = userEvent.setup();
+    api.post.mockResolvedValueOnce(SETUP); // /totp/setup
+    renderIt();
+
+    expect(await screen.findByText("users.twoFactor.disabledChip")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "users.twoFactor.setup" }));
+
+    // Step screen: manual key + all recovery codes visible.
+    expect(await screen.findByText("BASE32SECRET")).toBeInTheDocument();
+    for (const code of SETUP.recovery_codes) {
+      expect(screen.getByText(code)).toBeInTheDocument();
+    }
+
+    // Enable requires a 6-digit code AND the password.
+    const enable = screen.getByRole("button", { name: "users.twoFactor.enable" });
+    expect(enable).toBeDisabled();
+    await user.type(screen.getByLabelText("users.twoFactor.code"), "123456");
+    expect(enable).toBeDisabled();
+    await user.type(screen.getByLabelText("users.twoFactor.password"), "pw");
+    expect(enable).toBeEnabled();
+
+    api.post.mockResolvedValueOnce({}); // /totp/enable
+    api.get.mockResolvedValue({ enabled: true, enforced: false });
+    await user.click(enable);
+
+    await waitFor(() =>
+      expect(api.post).toHaveBeenCalledWith(
+        "/users/bob/totp/enable",
+        { code: "123456", password: "pw" },
+        "tok"
+      )
+    );
+    expect(toast.success).toHaveBeenCalledWith("users.twoFactor.enabledSuccess");
+    expect(await screen.findByText("users.twoFactor.enabledChip")).toBeInTheDocument();
+  });
+
+  it("surfaces the server detail when the code is rejected", async () => {
+    const user = userEvent.setup();
+    api.post.mockResolvedValueOnce(SETUP);
+    renderIt();
+    await user.click(await screen.findByRole("button", { name: "users.twoFactor.setup" }));
+    await screen.findByText("BASE32SECRET");
+
+    await user.type(screen.getByLabelText("users.twoFactor.code"), "999999");
+    await user.type(screen.getByLabelText("users.twoFactor.password"), "pw");
+    api.post.mockRejectedValueOnce({ response: { data: { detail: "Code mismatch" } } });
+    await user.click(screen.getByRole("button", { name: "users.twoFactor.enable" }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Code mismatch"));
+  });
+});
+
+describe("TwoFactorAuth disable flow", () => {
+  beforeEach(() => {
+    api.get.mockResolvedValue({ enabled: true, enforced: false });
+  });
+
+  it("reveals the password confirmation and disables 2FA (self only)", async () => {
+    const user = userEvent.setup();
+    renderIt();
+
+    await user.click(await screen.findByRole("button", { name: "users.twoFactor.disable" }));
+    await user.type(screen.getByLabelText("users.twoFactor.confirmPassword"), "pw");
+
+    api.post.mockResolvedValueOnce({});
+    api.get.mockResolvedValue({ enabled: false, enforced: false });
+    await user.click(screen.getByRole("button", { name: "users.twoFactor.confirmDisable" }));
+
+    await waitFor(() =>
+      expect(api.post).toHaveBeenCalledWith("/users/bob/totp/disable", { password: "pw" }, "tok")
+    );
+    expect(toast.success).toHaveBeenCalledWith("users.twoFactor.disabledSuccess");
+  });
+
+  it("blocks disabling when 2FA is platform-enforced", async () => {
+    api.get.mockResolvedValue({ enabled: true, enforced: true });
+    renderIt();
+
+    expect(await screen.findByText("users.twoFactor.enforced")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "users.twoFactor.cannotDisable" })
+    ).toBeDisabled();
+  });
+
+  it("hides the disable control when viewing someone else's profile", async () => {
+    useAuth.mockReturnValue({ user: { token: "tok", username: "someone-else" } });
+    renderIt();
+
+    expect(await screen.findByText("users.twoFactor.enabledChip")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "users.twoFactor.disable" })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/views/users/components/UserActivity.test.jsx
+++ b/frontend/src/app/views/users/components/UserActivity.test.jsx
@@ -1,0 +1,99 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import UserActivity from "./UserActivity";
+import api from "app/utils/api";
+import useAuth from "app/hooks/useAuth";
+import { usePlatformCapabilities } from "app/contexts/PlatformContext";
+
+jest.mock("app/utils/api", () => ({ get: jest.fn() }));
+jest.mock("react-i18next", () => ({ useTranslation: () => ({ t: (k) => k }) }));
+jest.mock("app/hooks/useAuth", () => jest.fn());
+jest.mock("app/contexts/PlatformContext", () => ({ usePlatformCapabilities: jest.fn() }));
+// Recharts is SVG/measurement heavy — stub it out; we only assert on our own DOM.
+jest.mock("recharts", () => {
+  const React = require("react");
+  const Stub = ({ children }) => React.createElement("div", null, children);
+  return {
+    ResponsiveContainer: Stub,
+    AreaChart: Stub,
+    BarChart: Stub,
+    Area: () => null,
+    Bar: () => null,
+    XAxis: () => null,
+    YAxis: () => null,
+    CartesianGrid: () => null,
+    Tooltip: () => null,
+  };
+});
+
+const STATS = {
+  summary: {
+    total_requests: 1234,
+    total_tokens: 56789,
+    total_cost: 1.2345,
+    avg_latency_ms: 250,
+    total_conversations: 42,
+  },
+  daily: [{ date: "2026-07-01", requests: 10 }],
+  hourly: [{ hour: 9, requests: 5 }],
+  top_projects: [
+    { project_id: 1, project_name: "support-bot", requests: 900, tokens: 40000 },
+  ],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useAuth.mockReturnValue({ user: { token: "tok", username: "admin" } });
+  usePlatformCapabilities.mockReturnValue({ platformCapabilities: { currency: "USD" } });
+  api.get.mockResolvedValue(STATS);
+});
+
+describe("UserActivity", () => {
+  it("fetches 30-day stats for the user and renders the summary cards", async () => {
+    render(<UserActivity user={{ id: 7 }} />);
+
+    expect(await screen.findByText("users.userActivity.title")).toBeInTheDocument();
+    expect(api.get).toHaveBeenCalledWith("/statistics/users/7?days=30", "tok", { silent: true });
+
+    expect(screen.getByText("1,234")).toBeInTheDocument(); // requests
+    expect(screen.getByText("56,789")).toBeInTheDocument(); // tokens
+    expect(screen.getByText("$1.234")).toBeInTheDocument(); // cost, 3 decimals
+    expect(screen.getByText("250ms")).toBeInTheDocument(); // latency in ms
+    expect(screen.getByText("42")).toBeInTheDocument(); // conversations
+
+    // Section headers + top-projects table.
+    expect(screen.getByText("users.userActivity.dailyActivity")).toBeInTheDocument();
+    expect(screen.getByText("users.userActivity.peakHours")).toBeInTheDocument();
+    expect(screen.getByText("support-bot")).toBeInTheDocument();
+    expect(screen.getByText("900")).toBeInTheDocument();
+    expect(screen.getByText("40,000")).toBeInTheDocument();
+  });
+
+  it("formats latency above one second in seconds", async () => {
+    api.get.mockResolvedValue({ summary: { ...STATS.summary, avg_latency_ms: 2500 } });
+    render(<UserActivity user={{ id: 7 }} />);
+
+    expect(await screen.findByText("2.5s")).toBeInTheDocument();
+  });
+
+  it("uses the platform currency symbol", async () => {
+    usePlatformCapabilities.mockReturnValue({ platformCapabilities: { currency: "EUR" } });
+    render(<UserActivity user={{ id: 7 }} />);
+
+    expect(await screen.findByText("€1.234")).toBeInTheDocument();
+  });
+
+  it("renders nothing when the fetch fails", async () => {
+    api.get.mockRejectedValue(new Error("boom"));
+    const { container } = render(<UserActivity user={{ id: 7 }} />);
+
+    await waitFor(() => expect(api.get).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("skips the fetch entirely when the user has no id", () => {
+    const { container } = render(<UserActivity user={{}} />);
+
+    expect(api.get).not.toHaveBeenCalled();
+    expect(container).toBeEmptyDOMElement();
+  });
+});


### PR DESCRIPTION
Follow-up to #204. Three multi-agent parallel sweeps grow both test suites dramatically and surface real bugs at every layer.

## Numbers

| | Before | After |
|---|---|---|
| Backend tests | 794 | **1,442** (all passing, ~2 min) |
| Backend coverage | 47.9% | **62.2%** |
| Frontend tests | 50 | **677** across 98 suites (all passing) |
| Frontend coverage | 0.9% | **50.4% stmts / 52.0% lines** (CI ratchet raised to 49/44/45/50) |

## New backend test areas (this PR)

- **All 10 cron modules** (were 0%; now 80–99%): runner discovery/flock/timeout-escalation, telegram/slack pollers with per-message error isolation, routines scheduling + webhook emission, bulk-ingest claim/dispatch/cleanup, memory-index cursor logic, docker/browser cleanup heartbeats.
- **Knowledge-sync engine** (7.8% → 88%): per-source dispatch, interval gating, SSRF guard, Confluence/S3/SharePoint/GDrive flows fully mocked.
- **Agent internals**: block interpreter 56→87% (all handlers, flow control, procedures), agent_shared 20→86%, agent2 providers 37→86% + compression 46→89% (faked-SDK streaming, fragmented tool calls), eval orchestration 11→74%, helper plumbing (chat_main dispatch, stream cost enrichment, expanded SSRF table).
- **Router edges**: projects/core validation + guard resolution, teams budgets/transactions/invitations, users API-key scoping + permission matrix, tools openai-compat/MCP with mocked HTTP, analytics with seeded rows, kg/query branch table, WhatsApp webhook with real HMAC signatures.

## New frontend test areas (this PR beyond #204)

Login/TOTP/SSO, account security (2FA lifecycle, API keys), users admin, teams (edit/view/analytics/wallet/billing dialogs), LLM + embeddings admin (incl. delete-with-reassign and detail panels), Ollama browser, image generators, Settings/GpuInfo/STT, dashboard + SmartSearch + charts, shared component library + layout shell, **and the whole projects domain**: edit shell + 6 tab components, observability views (logs/analytics/tokens/evals), template library, knowledge-graph panels.

## Bugs FIXED in this PR (13, all regression-tested)

1. `MatxVerticalNav`: sidebar active-route styling was dead (emotion stringified NavLink's function-className).
2. `BasicInformation`: SSO field was a broken controlled input.
3. Profile `Projects`: mutated the `user` prop in place.
4. `ProjectsTable`: Gravatar hashed the username instead of the email.
5. `SmartSearch`: keyboard focus lost after every search.
6. `users/List`: silently swallowed single-delete failures.
7. `users/Info`: dead `GET /info` per mount; missing Suspended pill.
8. `users/New`: "digit" password rule matched any symbol.
9. `Settings`: wholesale `setForm` flipped server-omitted fields to uncontrolled.
10. `speech_to_text/List`: stale dialog form state (out-of-range Select).
11. `TeamEdit`: Autocomplete reference-equality defeated `filterSelectedOptions`.
12. DOM prop leaks (`JwtLogin`/`Typography`/`AvatarBadge`/`ChatAvatar`).
13. `getTimeDifference` 3660→3600.

## NEW bugs documented by this sweep (not yet fixed — candidates for follow-up)

**Backend (serious):**
1. `integrations/sync.py` imports `extract_and_persist` from a stale module path (`restai.knowledge_graph` instead of `restai.integrations.knowledge_graph`); the `ModuleNotFoundError` is swallowed, so **sync-time knowledge-graph extraction silently never runs**.
2. `_sync_s3`/`_sync_sharepoint`/`_sync_gdrive` treat `find_file_loader`'s return as a class and dead-check for `None`, but it returns an instance and raises on unsupported types — **file-based source sync cannot have worked end-to-end** (`loader_cls()` → `TypeError` on any supported file).
3. `GET /tools/openai-compat/models/{llm_id}` sends the **Fernet-encrypted API key upstream** (`Bearer $ENC$...`) — always 401s against real providers; needs `decrypt_sensitive_options` like every other consumer.
4. SSRF guard doesn't block CGNAT `100.64.0.0/10` despite its docstring claiming "CGNAT-ish" coverage.

**Frontend:**
5. `ProjectEdit.jsx`: operator-precedence bug (`!project.type === "agent"`) makes per-type tab gating dead — block projects see the System tab; same pattern in `ProjectEditIntegrations.jsx`.
6. `ProjectEdit.jsx`: dirty-tracking baseline is snapshotted before async hydration, so real projects show unsaved-changes immediately.
7. `ProjectEditSecurity.jsx`: the Budget field's edits are silently discarded (writes to a top-level key the submit never maps).
8. `ProjectAnalytics`/`ProjectTokens`: day keys built with local-time `Date` then UTC-serialized — daily data points shift a day in positive-UTC-offset timezones (`TeamAnalytics` does it right with `Date.UTC`).

## Notes

- ESM-only deps (`boring-avatars`, `react-qr-code`, `@microlink/react-json-view`, `vis-network`, chart libs, `mui-datatables`) stubbed via `jest.mock`; nothing renders `react-markdown` (pattern in CLAUDE.md).
- Backend agent tests are fully offline: network/vendor SDKs mocked, real sqlite + live TestClient app for router tests.
- Docs nit: CLAUDE.md describes the LLM reassign-delete endpoint as keyed by name; code deletes by id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDhwNEsAPLBswKQAVqruuV